### PR TITLE
Feat : 오픈소스 라이센스 화면 UI 및 로직 구성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,5 +119,4 @@ dependencies {
 
     // MinSdk
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.YouDongKnowMe">
         <activity
-            android:name=".LicenseActivity"
+            android:name=".ui.view.license.LicenseActivity"
             android:exported="false" />
         <activity
             android:name=".ui.view.alarm.AlarmActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,12 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.YouDongKnowMe">
         <activity
-            android:name=".ui.view.alarm.AlarmActivity"
-            android:launchMode="singleTask"
+            android:name=".LicenseActivity"
             android:exported="false" />
+        <activity
+            android:name=".ui.view.alarm.AlarmActivity"
+            android:exported="false"
+            android:launchMode="singleTask" />
         <activity
             android:name=".ui.view.keyword.KeywordActivity"
             android:exported="false" />

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/entity/OpenSourceEntity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/entity/OpenSourceEntity.kt
@@ -1,46 +1,56 @@
 package com.dongyang.android.youdongknowme.data.local.entity
 
-data class OpenSourceEntity (
-    val name : String,
-    val url : String,
+data class OpenSourceEntity(
+    val name: String,
+    val url: String,
+    val license: String,
 ) {
     companion object {
         val openSourceList = listOf<OpenSourceEntity>(
             OpenSourceEntity(
                 "okhttp3",
-                "https://github.com/square/okhttp/blob/master/LICENSE.txt"
+                "https://github.com/square/okhttp/blob/master/LICENSE.txt",
+                "Apache"
             ),
             OpenSourceEntity(
                 "retrofit2",
-                "https://github.com/square/retrofit/blob/master/LICENSE.txt"
+                "https://github.com/square/retrofit/blob/master/LICENSE.txt",
+                "Apache"
             ),
             OpenSourceEntity(
                 "firebase",
-                "https://firebase.google.com/terms"
+                "https://firebase.google.com/terms",
+                "Apache"
             ),
             OpenSourceEntity(
                 "glide",
-                "https://github.com/bumptech/glide/blob/master/LICENSE"
+                "https://github.com/bumptech/glide/blob/master/LICENSE",
+                "Apache"
             ),
             OpenSourceEntity(
                 "gson",
-                "https://github.com/google/gson/blob/master/LICENSE"
+                "https://github.com/google/gson/blob/master/LICENSE",
+                "Apache"
             ),
             OpenSourceEntity(
                 "AndroidViewAnimations",
-                "https://github.com/daimajia/AndroidViewAnimations/blob/master/License"
+                "https://github.com/daimajia/AndroidViewAnimations/blob/master/License",
+                "MIT"
             ),
             OpenSourceEntity(
                 "lottie",
-                "https://github.com/airbnb/lottie-android/blob/master/LICENSE"
+                "https://github.com/airbnb/lottie-android/blob/master/LICENSE",
+                "Apache"
             ),
             OpenSourceEntity(
                 "MaterialCalendarView",
-                "https://github.com/prolificinteractive/material-calendarview/blob/master/LICENSE"
+                "https://github.com/prolificinteractive/material-calendarview/blob/master/LICENSE",
+                "MIT"
             ),
             OpenSourceEntity(
                 "CalendarView",
-                "https://github.com/kizitonwose/CalendarView/blob/master/LICENSE.md"
+                "https://github.com/kizitonwose/CalendarView/blob/master/LICENSE.md",
+                "MIT"
             ),
         )
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/entity/OpenSourceEntity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/entity/OpenSourceEntity.kt
@@ -1,0 +1,47 @@
+package com.dongyang.android.youdongknowme.data.local.entity
+
+data class OpenSourceEntity (
+    val name : String,
+    val url : String,
+) {
+    companion object {
+        val openSourceList = listOf<OpenSourceEntity>(
+            OpenSourceEntity(
+                "okhttp3",
+                "https://github.com/square/okhttp/blob/master/LICENSE.txt"
+            ),
+            OpenSourceEntity(
+                "retrofit2",
+                "https://github.com/square/retrofit/blob/master/LICENSE.txt"
+            ),
+            OpenSourceEntity(
+                "firebase",
+                "https://firebase.google.com/terms"
+            ),
+            OpenSourceEntity(
+                "glide",
+                "https://github.com/bumptech/glide/blob/master/LICENSE"
+            ),
+            OpenSourceEntity(
+                "gson",
+                "https://github.com/google/gson/blob/master/LICENSE"
+            ),
+            OpenSourceEntity(
+                "AndroidViewAnimations",
+                "https://github.com/daimajia/AndroidViewAnimations/blob/master/License"
+            ),
+            OpenSourceEntity(
+                "lottie",
+                "https://github.com/airbnb/lottie-android/blob/master/LICENSE"
+            ),
+            OpenSourceEntity(
+                "MaterialCalendarView",
+                "https://github.com/prolificinteractive/material-calendarview/blob/master/LICENSE"
+            ),
+            OpenSourceEntity(
+                "CalendarView",
+                "https://github.com/kizitonwose/CalendarView/blob/master/LICENSE.md"
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/entity/OpenSourceEntity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/entity/OpenSourceEntity.kt
@@ -8,23 +8,23 @@ data class OpenSourceEntity(
     companion object {
         val openSourceList = listOf<OpenSourceEntity>(
             OpenSourceEntity(
-                "okhttp3",
-                "https://github.com/square/okhttp/blob/master/LICENSE.txt",
-                "Apache"
-            ),
-            OpenSourceEntity(
-                "retrofit2",
-                "https://github.com/square/retrofit/blob/master/LICENSE.txt",
-                "Apache"
-            ),
-            OpenSourceEntity(
-                "firebase",
+                "Firebase",
                 "https://firebase.google.com/terms",
                 "Apache"
             ),
             OpenSourceEntity(
                 "glide",
                 "https://github.com/bumptech/glide/blob/master/LICENSE",
+                "Apache"
+            ),
+            OpenSourceEntity(
+                "okhttp",
+                "https://github.com/square/okhttp/blob/master/LICENSE.txt",
+                "Apache"
+            ),
+            OpenSourceEntity(
+                "retrofit",
+                "https://github.com/square/retrofit/blob/master/LICENSE.txt",
                 "Apache"
             ),
             OpenSourceEntity(

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -12,6 +12,7 @@ import com.dongyang.android.youdongknowme.ui.view.cafeteria.CafeteriaViewModel
 import com.dongyang.android.youdongknowme.ui.view.depart.DepartViewModel
 import com.dongyang.android.youdongknowme.ui.view.detail.DetailViewModel
 import com.dongyang.android.youdongknowme.ui.view.keyword.KeywordViewModel
+import com.dongyang.android.youdongknowme.ui.view.license.LicenseViewModel
 import com.dongyang.android.youdongknowme.ui.view.notice.NoticeViewModel
 import com.dongyang.android.youdongknowme.ui.view.schedule.ScheduleViewModel
 import com.dongyang.android.youdongknowme.ui.view.setting.SettingViewModel
@@ -82,6 +83,9 @@ val viewModelModule = module {
     }
     viewModel {
         CafeteriaViewModel(get(), get())
+    }
+    viewModel {
+        LicenseViewModel()
     }
 }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/LicenseAdapter.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/LicenseAdapter.kt
@@ -1,0 +1,46 @@
+package com.dongyang.android.youdongknowme.ui.adapter
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.dongyang.android.youdongknowme.data.local.entity.OpenSourceEntity
+import com.dongyang.android.youdongknowme.databinding.ItemLicenseBinding
+import com.dongyang.android.youdongknowme.ui.view.license.LicenseClickListener
+
+class LicenseAdapter : RecyclerView.Adapter<LicenseAdapter.ViewHolder>() {
+
+    private val item = ArrayList<OpenSourceEntity>()
+    private var itemClickListener: LicenseClickListener? = null
+
+    inner class ViewHolder(private val binding: ItemLicenseBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: OpenSourceEntity) {
+            binding.openSource = item
+            binding.itemClickListener = itemClickListener
+        }
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun submitList(item: List<OpenSourceEntity>) {
+        this.item.clear()
+        this.item.addAll(item)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            ItemLicenseBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) = holder.bind(item[position])
+
+    override fun getItemCount(): Int = item.size
+
+    fun setItemClickListener(listener: LicenseClickListener) {
+        itemClickListener = listener
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/alarm/AlarmActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/alarm/AlarmActivity.kt
@@ -36,7 +36,7 @@ class AlarmActivity : BaseActivity<ActivityAlarmBinding, AlarmViewModel>(), Alar
     override fun initAfterBinding() {
         viewModel.getAlarms()
 
-        binding.alarmExitBtn.setOnClickListener {
+        binding.alarmToolbar.toolbarExit.setOnClickListener {
             finish()
         }
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartActivity.kt
@@ -47,7 +47,7 @@ class DepartActivity : AppCompatActivity(), DepartClickListener {
             this.setHasFixedSize(true)
         }
 
-        binding.departExitBtn.setOnClickListener {
+        binding.departToolbar.toolbarExit.setOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
@@ -88,7 +88,7 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>(), D
         viewModel.fetchNoticeDetail()
 
         // 뒤로가기 버튼 클릭 시
-        binding.detailExitBtn.setOnClickListener {
+        binding.detailToolbar.toolbarExit.setOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/keyword/KeywordActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/keyword/KeywordActivity.kt
@@ -45,7 +45,7 @@ class KeywordActivity : BaseActivity<ActivityKeywordBinding, KeywordViewModel>()
         viewModel.getLocalKeywordList()
 
         // 뒤로가기 버튼 눌렀을 때
-        binding.keywordExitBtn.setOnClickListener {
+        binding.keywordToolbar.toolbarExit.setOnClickListener {
             finish()
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseActivity.kt
@@ -1,12 +1,23 @@
 package com.dongyang.android.youdongknowme.ui.view.license
 
-import androidx.appcompat.app.AppCompatActivity
-import android.os.Bundle
 import com.dongyang.android.youdongknowme.R
+import com.dongyang.android.youdongknowme.databinding.ActivityLicenseBinding
+import com.dongyang.android.youdongknowme.standard.base.BaseActivity
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class LicenseActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_license)
+class LicenseActivity : BaseActivity<ActivityLicenseBinding, LicenseViewModel>() {
+    override val layoutResourceId: Int = R.layout.activity_license
+    override val viewModel: LicenseViewModel by viewModel()
+
+    override fun initStartView() {
+
+    }
+
+    override fun initDataBinding() {
+
+    }
+
+    override fun initAfterBinding() {
+
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseActivity.kt
@@ -1,0 +1,12 @@
+package com.dongyang.android.youdongknowme.ui.view.license
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.dongyang.android.youdongknowme.R
+
+class LicenseActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_license)
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseActivity.kt
@@ -1,23 +1,43 @@
 package com.dongyang.android.youdongknowme.ui.view.license
 
+import android.content.Intent
+import android.net.Uri
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.dongyang.android.youdongknowme.R
+import com.dongyang.android.youdongknowme.data.local.entity.OpenSourceEntity
 import com.dongyang.android.youdongknowme.databinding.ActivityLicenseBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseActivity
+import com.dongyang.android.youdongknowme.ui.adapter.LicenseAdapter
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class LicenseActivity : BaseActivity<ActivityLicenseBinding, LicenseViewModel>() {
+class LicenseActivity : BaseActivity<ActivityLicenseBinding, LicenseViewModel>(),
+    LicenseClickListener {
     override val layoutResourceId: Int = R.layout.activity_license
     override val viewModel: LicenseViewModel by viewModel()
 
+    lateinit var adapter: LicenseAdapter
+
     override fun initStartView() {
-
+        adapter = LicenseAdapter().apply { setItemClickListener(this@LicenseActivity) }
+        binding.licenseRcv.apply {
+            this.adapter = this@LicenseActivity.adapter
+            this.layoutManager = LinearLayoutManager(this@LicenseActivity)
+            this.addItemDecoration(DividerItemDecoration(this@LicenseActivity, 1))
+            this.setHasFixedSize(true)
+        }
     }
 
-    override fun initDataBinding() {
-
-    }
+    override fun initDataBinding() {}
 
     override fun initAfterBinding() {
+        adapter.submitList(OpenSourceEntity.openSourceList)
 
+        binding.licenseToolbar.toolbarExit.setOnClickListener { finish() }
+    }
+
+    override fun itemClick(openSourceEntity: OpenSourceEntity) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(openSourceEntity.url))
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseClickListener.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseClickListener.kt
@@ -1,0 +1,7 @@
+package com.dongyang.android.youdongknowme.ui.view.license
+
+import com.dongyang.android.youdongknowme.data.local.entity.OpenSourceEntity
+
+interface LicenseClickListener {
+    fun itemClick(openSourceEntity: OpenSourceEntity)
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/license/LicenseViewModel.kt
@@ -1,0 +1,7 @@
+package com.dongyang.android.youdongknowme.ui.view.license
+
+import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
+
+class LicenseViewModel : BaseViewModel() {
+    // NOT IMPLEMENTS
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -6,6 +6,7 @@ import com.dongyang.android.youdongknowme.databinding.FragmentSettingBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
 import com.dongyang.android.youdongknowme.ui.view.depart.DepartActivity
 import com.dongyang.android.youdongknowme.ui.view.keyword.KeywordActivity
+import com.dongyang.android.youdongknowme.ui.view.license.LicenseActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 /* 설정 화면 */
@@ -58,6 +59,11 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
 
         binding.settingKeyword.setOnClickListener {
             val intent = Intent(requireActivity(), KeywordActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.settingAppLicense.setOnClickListener {
+            val intent = Intent(requireActivity(), LicenseActivity::class.java)
             startActivity(intent)
         }
     }

--- a/app/src/main/res/layout/activity_alarm.xml
+++ b/app/src/main/res/layout/activity_alarm.xml
@@ -7,28 +7,13 @@
         android:layout_height="match_parent"
         tools:context=".ui.view.alarm.AlarmActivity">
 
-        <TextView
-            android:id="@+id/alarm_title"
-            style="@style/PretendardBold20"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/alarm_title"
-            android:textColor="@color/black"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageButton
-            android:id="@+id/alarm_exit_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <include
+            android:id="@+id/alarm_toolbar"
+            layout="@layout/standard_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            app:exitVisible="@{true}"
+            app:title="@{@string/alarm_title}" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/alarm_rcv"
@@ -36,7 +21,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/alarm_title"
+            app:layout_constraintTop_toBottomOf="@id/alarm_toolbar"
             tools:listitem="@layout/item_alarm" />
 
         <LinearLayout
@@ -48,7 +33,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/alarm_title">
+            app:layout_constraintTop_toBottomOf="@id/alarm_toolbar">
 
             <ImageView
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_depart.xml
+++ b/app/src/main/res/layout/activity_depart.xml
@@ -7,29 +7,13 @@
         android:layout_height="match_parent"
         tools:context=".ui.view.depart.DepartActivity">
 
-        <TextView
-            android:id="@+id/depart_title"
-            style="@style/PretendardBold20"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/department_title"
-            android:textColor="@color/black"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageButton
-            android:id="@+id/depart_exit_btn"
-            bind_visibility_is_first_launch="@{vm.isFirstLaunch()}"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <include
+            android:id="@+id/depart_toolbar"
+            layout="@layout/standard_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            app:exitVisible="@{!vm.isFirstLaunch()}"
+            app:title="@{@string/department_title}" />
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/depart_container"
@@ -37,7 +21,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/depart_title">
+            app:layout_constraintTop_toBottomOf="@id/depart_toolbar">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/depart_rcv"

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -8,27 +8,13 @@
         android:layout_height="match_parent"
         tools:context=".ui.view.detail.DetailActivity">
 
-        <TextView
-            style="@style/PretendardBold20"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/detail_title"
-            android:textColor="@color/black"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageButton
-            android:id="@+id/detail_exit_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <include
+            android:id="@+id/detail_toolbar"
+            layout="@layout/standard_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            app:title="@{@string/detail_title}"
+            app:exitVisible="@{true}"/>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_keyword.xml
+++ b/app/src/main/res/layout/activity_keyword.xml
@@ -8,29 +8,13 @@
         android:layout_height="match_parent"
         tools:context=".ui.view.keyword.KeywordActivity">
 
-        <TextView
-            android:id="@+id/keyword_title"
-            style="@style/PretendardBold20"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/keyword_title"
-            android:textColor="@color/black"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageButton
-            android:id="@+id/keyword_exit_btn"
-            bind_visibility_is_first_launch="@{vm.isFirstLaunch()}"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <include
+            android:id="@+id/keyword_toolbar"
+            layout="@layout/standard_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            app:title="@{@string/keyword_title}"
+            app:exitVisible="@{!vm.isFirstLaunch()}"/>
 
         <ScrollView
             android:id="@+id/keyword_scroll_view"
@@ -43,7 +27,7 @@
             app:layout_constraintBottom_toTopOf="@id/keyword_complete_btn"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/keyword_title">
+            app:layout_constraintTop_toBottomOf="@id/keyword_toolbar">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".ui.view.license.LicenseActivity">
+<layout>
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:text="empty activity" />
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.view.license.LicenseActivity">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="empty activity"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -8,14 +8,22 @@
         android:layout_height="match_parent"
         tools:context=".ui.view.license.LicenseActivity">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="empty activity"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+        <include
+            android:id="@+id/license_toolbar"
+            layout="@layout/standard_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            app:title="@{@string/license_title}"
+            app:exitVisible="@{true}"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/license_rcv"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/license_toolbar"
+            tools:listitem="@layout/item_license"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".ui.view.license.LicenseActivity">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="empty activity" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_license.xml
+++ b/app/src/main/res/layout/item_license.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/item_license_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:onClick="@{() -> itemClickListener.itemClick(openSource)}"
+        android:foreground="?attr/selectableItemBackground">
+
+        <TextView
+            android:id="@+id/item_license_title"
+            style="@style/PretendardBold20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="16dp"
+            android:layout_marginStart="24dp"
+            android:text="@{openSource.name}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            style="@style/PretendardRegular12"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@{openSource.license}"
+            android:textColor="@color/line"
+            app:layout_constraintBottom_toBottomOf="@id/item_license_title"
+            app:layout_constraintStart_toEndOf="@id/item_license_title" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <data>
+
+        <variable
+            name="openSource"
+            type="com.dongyang.android.youdongknowme.data.local.entity.OpenSourceEntity" />
+
+        <variable
+            name="itemClickListener"
+            type="com.dongyang.android.youdongknowme.ui.view.license.LicenseClickListener" />
+    </data>
+</layout>

--- a/app/src/main/res/layout/standard_toolbar.xml
+++ b/app/src/main/res/layout/standard_toolbar.xml
@@ -6,6 +6,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <ImageButton
+            android:id="@+id/toolbar_exit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:visibility="@{exitVisible ? View.VISIBLE:View.GONE}"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_back"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <TextView
             android:id="@+id/toolbar_title"
             style="@style/PretendardBold20"
@@ -25,7 +37,6 @@
             android:layout_marginStart="8dp"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="8dp"
-            android:visibility="visible"
             app:bind_visibility_search="@{vm.isSearchMode}"
             app:cardCornerRadius="18dp"
             app:cardUseCompatPadding="true"
@@ -63,9 +74,7 @@
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:gravity="center"
                     android:src="@drawable/ic_close_black" />
-
             </LinearLayout>
-
         </androidx.cardview.widget.CardView>
 
         <ImageButton
@@ -79,7 +88,6 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-
 
         <FrameLayout
             android:id="@+id/toolbar_alarm_container"
@@ -105,8 +113,11 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <data>
-
         <import type="android.view.View" />
+
+        <variable
+            name="exitVisible"
+            type="java.lang.Boolean"/>
 
         <variable
             name="title"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="setting_app_info">앱 정보</string>
     <string name="setting_app_help">문의하기</string>
     <string name="setting_app_version">앱 버전</string>
-    <string name="setting_app_license">오픈소스 라이선스</string>
+    <string name="setting_app_license">오픈소스 라이센스</string>
 
     <!-- calendar -->
     <string name="calendar_year">년</string>
@@ -106,4 +106,7 @@
     <string name="cafeteria_time">11:30 ~ 14:00</string>
     <string name="cafeteria_place">8호관 3층</string>
     <string name="cafeteria_no_menu">&#128517; 등록된 메뉴가 없어요.</string>
+
+    <!-- license -->
+    <string name="license_title">오픈소스 라이센스</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'com.android.application' version '7.1.2' apply false
     id 'com.android.library' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
     id "com.google.gms.google-services" version "4.3.10" apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'com.android.application' version '7.1.2' apply false
     id 'com.android.library' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
     id "com.google.gms.google-services" version "4.3.10" apply false
 }
 


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #104 

## ✍️ 구현 내용

![Screenshot_1661410377 중간](https://user-images.githubusercontent.com/85336456/186595633-9e27ed77-7c21-40d9-ae38-d1eee63a30ce.png)
![Screenshot_1661410384 중간](https://user-images.githubusercontent.com/85336456/186595624-15aef448-36ca-4a5b-9c9b-49a9d5517026.png)

- 오픈소스 라이센스 화면 UI 구성
- 클릭 시 해당 오픈소스의 라이센스 페이지로 이동하도록 설정

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
