### PR TITLE
Fix : 오늘의 식단 화면 캘린더의 색상 표현 오류 해결

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,41 +44,40 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.1'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
 
-    implementation 'androidx.preference:preference:1.1.0-rc01'
+    // preference
+    implementation 'androidx.preference:preference:1.2.0'
 
     // Coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
     // ViewModelScope
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
 
     // Retrofit2
-    def retrofit_version = "2.9.0"
-    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.9.0"
 
     // OkHttp
-    implementation "com.squareup.okhttp3:okhttp:4.9.3"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.3"
+    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.1"
 
     // Gson
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
 
     // Room
-    def room_version = "2.4.2"
-    implementation 'androidx.room:room-common:2.4.2'
-    implementation 'androidx.room:room-ktx:2.4.2'
-    kapt "androidx.room:room-compiler:$room_version"
+    implementation 'androidx.room:room-common:2.4.3'
+    implementation 'androidx.room:room-ktx:2.4.3'
+    kapt "androidx.room:room-compiler:2.4.3"
 
     // Koin
     implementation "io.insert-koin:koin-core:3.1.2"
@@ -93,13 +92,13 @@ dependencies {
     implementation 'com.jakewharton.threetenabp:threetenabp:1.2.0'
 
     // Glide
-    implementation 'com.github.bumptech.glide:glide:4.13.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.13.0'
+    implementation 'com.github.bumptech.glide:glide:4.13.2'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.13.2'
 
     // Firebase
     implementation platform('com.google.firebase:firebase-bom:30.0.0')
     implementation 'com.google.firebase:firebase-analytics'
-    implementation 'com.google.firebase:firebase-messaging:23.0.5'
+    implementation 'com.google.firebase:firebase-messaging:23.1.0'
 
     // Timber
     implementation 'com.jakewharton.timber:timber:5.0.1'
@@ -114,8 +113,8 @@ dependencies {
     implementation "com.airbnb.android:lottie:5.2.0"
 
     // Navigation
-    implementation("androidx.navigation:navigation-fragment-ktx:2.5.1")
-    implementation("androidx.navigation:navigation-ui-ktx:2.5.1")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.5.3")
+    implementation("androidx.navigation:navigation-ui-ktx:2.5.3")
 
     // MinSdk
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,4 +119,7 @@ dependencies {
 
     // MinSdk
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
+    // Window Manager
+    implementation 'androidx.window:window:1.0.0'
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaContainer.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaContainer.kt
@@ -39,7 +39,11 @@ class CafeteriaContainer(
         bind.itemCalendarDate.setTextColor(
             ContextCompat.getColor(
                 view.context,
-                if (day.date == viewModel.selectedDate.value) R.color.main else R.color.black
+                if (day.date == viewModel.selectedDate.value) {
+                    R.color.main
+                } else {
+                    R.color.black
+                }
             )
         )
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -1,9 +1,7 @@
 package com.dongyang.android.youdongknowme.ui.view.cafeteria
 
-import android.content.Context
-import android.util.DisplayMetrics
 import android.view.View
-import android.view.WindowManager
+import androidx.window.layout.WindowMetricsCalculator
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentCafeteriaBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
@@ -20,7 +18,9 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
 
-class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewModel>(), CalendarInterface {
+
+class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewModel>(),
+    CalendarInterface {
 
     override val layoutResourceId: Int = R.layout.fragment_cafeteria
     override val viewModel: CafeteriaViewModel by viewModel()
@@ -50,14 +50,13 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             this.setHasFixedSize(true)
         }
 
-        val dm = DisplayMetrics()
-        val wm = requireContext().getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val wmc =
+            WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(requireActivity())
 
-        // TODO : deprecated -> 수정 필요
-        wm.defaultDisplay.getMetrics(dm)
         binding.cafeteriaCalendar.apply {
-            val dayWidth = dm.widthPixels / 5
-            val dayHeight = (dayWidth * 1.25).toInt()
+            val dayWidth = wmc.bounds.width() / 5
+            val dayHeight: Int = (dayWidth * 1.25).toInt()
+
             daySize = Size(dayWidth, dayHeight)
         }
 
@@ -91,7 +90,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
 
     override fun initAfterBinding() {
         binding.cafeteriaCalendar.setup(
-            YearMonth.now().minusMonths(1),
+            YearMonth.now().minusMonths(2),
             YearMonth.now().plusMonths(1),
             DayOfWeek.values().random()
         )

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -102,19 +102,13 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
         }
     }
 
-    override fun onHiddenChanged(hidden: Boolean) {
-        super.onHiddenChanged(hidden)
-        if (!hidden) {
-            binding.cafeteriaCalendar.stopScroll()
-            binding.cafeteriaCalendar.smoothScrollToDate(LocalDate.now().minusDays(2))
-            notifyDateChanged(
-                viewModel,
-                binding.cafeteriaCalendar,
-                viewModel.selectedDate.value,
-                LocalDate.now()
-            )
-
-            if (viewModel.cafeteriaList.value == null) viewModel.fetchCafeteria()
-        }
+    override fun onPause() {
+        super.onPause()
+        notifyDateChanged(
+            viewModel,
+            binding.cafeteriaCalendar,
+            viewModel.selectedDate.value,
+            LocalDate.now()
+        )
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -64,7 +64,7 @@ class CafeteriaViewModel(
     }
 
     fun updateSelectedDate(selectedDate: LocalDate) {
-        _selectedDate.postValue(selectedDate)
+        _selectedDate.value = selectedDate
         updateMenuList(selectedDate.toString().replace("-", "."))
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CalendarInterface.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CalendarInterface.kt
@@ -4,7 +4,12 @@ import com.kizitonwose.calendarview.CalendarView
 import java.time.LocalDate
 
 interface CalendarInterface {
-    fun notifyDateChanged(viewModel: CafeteriaViewModel, calendarView: CalendarView, oldDate: LocalDate?, selectedDate: LocalDate) {
+    fun notifyDateChanged(
+        viewModel: CafeteriaViewModel,
+        calendarView: CalendarView,
+        oldDate: LocalDate?,
+        selectedDate: LocalDate
+    ) {
         viewModel.updateSelectedDate(selectedDate)
         calendarView.notifyDateChanged(selectedDate)
         oldDate?.let { calendarView.notifyDateChanged(it) }

--- a/app/src/main/res/layout/activity_depart.xml
+++ b/app/src/main/res/layout/activity_depart.xml
@@ -10,17 +10,21 @@
         <include
             android:id="@+id/depart_toolbar"
             layout="@layout/standard_toolbar"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="?android:attr/actionBarSize"
             app:exitVisible="@{!vm.isFirstLaunch()}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:title="@{@string/department_title}" />
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/depart_container"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/depart_toolbar">
 
             <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -11,17 +11,23 @@
         <include
             android:id="@+id/detail_toolbar"
             layout="@layout/standard_toolbar"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="?android:attr/actionBarSize"
-            app:title="@{@string/detail_title}"
-            app:exitVisible="@{true}"/>
+            app:exitVisible="@{true}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:title="@{@string/detail_title}" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="68dp"
+            bind_is_error="@{vm.title == null}"
             bind_is_loading="@{vm.isLoading()}"
-            bind_is_error="@{vm.title == null}">
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="68dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/detail_title"
@@ -63,11 +69,10 @@
 
             <View
                 android:id="@+id/detail_top_line"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="0.5dp"
-                android:layout_marginStart="16dp"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="16dp"
                 android:background="#A1333232"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -77,9 +82,8 @@
                 android:id="@+id/detail_file_rcv"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="8dp"
-                android:layout_marginEnd="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/detail_top_line"
@@ -89,9 +93,8 @@
                 android:id="@+id/detail_bot_line"
                 android:layout_width="match_parent"
                 android:layout_height="0.5dp"
-                android:layout_marginStart="16dp"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="16dp"
                 android:background="#A1333232"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -99,13 +102,14 @@
 
             <ScrollView
                 android:id="@+id/detail_scroll_view"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:layout_marginStart="16dp"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="12dp"
-                android:layout_marginEnd="16dp"
                 android:fillViewport="true"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/detail_bot_line">
 
                 <LinearLayout
@@ -133,8 +137,12 @@
         <LinearLayout
             bind_is_error="@{!vm.isError}"
             bind_is_loading="@{vm.isLoading()}"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <include
                 android:id="@+id/detail_error_container"

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -11,19 +11,22 @@
         <include
             android:id="@+id/license_toolbar"
             layout="@layout/standard_toolbar"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="?android:attr/actionBarSize"
-            app:title="@{@string/license_title}"
-            app:exitVisible="@{true}"/>
+            app:exitVisible="@{true}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:title="@{@string/license_title}" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/license_rcv"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/license_toolbar"
-            tools:listitem="@layout/item_license"/>
+            tools:listitem="@layout/item_license" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,17 +11,17 @@
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/main_nav_container"
             android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             app:defaultNavHost="true"
             app:layout_constraintBottom_toTopOf="@id/main_nv_bottom"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/main_nv_bottom"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="51dp"
             android:layout_gravity="bottom|center_horizontal"
             android:background="@drawable/bg_main_navi"

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -8,13 +8,13 @@
         tools:context=".ui.view.splash.SplashActivity">
 
         <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_constraintTop_toTopOf="parent"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:src="@drawable/ic_launcher_foreground"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:src="@drawable/ic_launcher_foreground" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -32,7 +32,7 @@
 
                 <com.kizitonwose.calendarview.CalendarView
                     android:id="@+id/cafeteria_calendar"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:cv_dayViewResource="@layout/item_calendar_day"
                     app:cv_hasBoundaries="false"
@@ -47,10 +47,12 @@
 
                 <LinearLayout
                     android:id="@+id/cafeteria_info_container"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
                     android:paddingHorizontal="16dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cafeteria_calendar">
 
                     <ImageView
@@ -108,13 +110,15 @@
                     android:id="@+id/cafeteria_stu_menu_container"
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="12dp"
                     android:background="@color/main"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container">
 
                     <TextView
@@ -140,13 +144,15 @@
                     android:id="@+id/cafeteria_emp_menu_container"
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="12dp"
                     android:background="@color/main"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cafeteria_stu_menu_container">
 
                     <TextView

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -10,8 +10,10 @@
         <include
             android:id="@+id/notice_toolbar"
             layout="@layout/standard_toolbar"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="?android:attr/actionBarSize"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:title="@{@string/notice_title}"
             app:vm="@{vm}" />
 
@@ -19,15 +21,19 @@
             android:id="@+id/notice_main_container"
             bind_is_error="@{vm.isError()}"
             bind_is_loading="@{vm.isLoading()}"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/notice_toolbar"
             tools:context=".ui.view.notice.NoticeFragment">
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/notice_tab"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:tabGravity="fill"
                 app:tabMaxWidth="0dp"
@@ -51,8 +57,10 @@
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/notice_swipe"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/notice_main_container">
 

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -11,8 +11,10 @@
         <include
             android:id="@+id/schedule_toolbar"
             layout="@layout/standard_toolbar"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="?android:attr/actionBarSize"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:title="@{@string/schedule_title}" />
 
         <com.prolificinteractive.materialcalendarview.MaterialCalendarView
@@ -29,9 +31,11 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/schedule_rv_list"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginTop="15dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/schedule_calendar"
             tools:listitem="@layout/item_schedule" />

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -9,15 +9,19 @@
         <include
             android:id="@+id/setting_toolbar"
             layout="@layout/standard_toolbar"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:title="@{@string/setting_title}" />
 
         <ScrollView
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginTop="24dp"
             android:fillViewport="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/setting_toolbar">
 

--- a/app/src/main/res/layout/item_alarm.xml
+++ b/app/src/main/res/layout/item_alarm.xml
@@ -8,7 +8,7 @@
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/item_alarm_container"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="8dp"
@@ -17,6 +17,8 @@
             android:onClick="@{() -> itemClickListener.itemClick(alarm)}"
             app:cardCornerRadius="16dp"
             app:cardElevation="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
@@ -9,10 +10,14 @@
         tools:background="@color/white">
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:gravity="center_vertical"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/item_calendar_month"

--- a/app/src/main/res/layout/item_depart.xml
+++ b/app/src/main/res/layout/item_depart.xml
@@ -8,7 +8,7 @@
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/item_depart_container"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="8dp"
@@ -18,6 +18,8 @@
             android:onClick="@{() -> itemClickListener.containerClick(currentPosition)}"
             app:cardCornerRadius="16dp"
             app:cardElevation="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_file.xml
+++ b/app/src/main/res/layout/item_file.xml
@@ -8,20 +8,22 @@
         <TextView
             android:id="@+id/item_file_not_found"
             style="@style/PretendardRegular12"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:padding="6dp"
             android:text="@string/detail_file_not_found_message"
             android:visibility="gone"
             app:bind_visibility_existence="@{file.name.empty}"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <Button
             android:id="@+id/item_file_btn"
             style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_bold"
             android:gravity="center_vertical"
             android:minHeight="0dp"
             android:onClick="@{() -> itemClickListener.fileClick(file.name, file.url)}"
@@ -30,8 +32,8 @@
             android:textColor="@color/main"
             android:textSize="12sp"
             android:textStyle="normal"
-            android:fontFamily="@font/pretendard_bold"
             app:bind_visibility_existence="@{!file.name.empty}"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/item_image.xml
+++ b/app/src/main/res/layout/item_image.xml
@@ -8,13 +8,15 @@
 
         <ImageView
             android:id="@+id/item_detail_iv"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:ignore="ContentDescription" />
 


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #102 

## ✍️ 구현 내용
- 오늘의 식단 화면 캘린더에서 색상이 잘못 표현되는 오류를 해결
   - `e.g.` 9일을 클릭했음에도 색상이 푸른색으로 변경되지 않는 경우, 색상이 한 번에 두 날짜에 표현되는 경우 등..
- 라이브러리 버전 업그레이드
- `constraintlayout` -> `match_parent` 로 설정되어 있던 것을 `match_constraint` 로 변경

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
