### PR TITLE
Fix : 국가장학금 키워드 삭제

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -5,7 +5,15 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.dongyang.android.youdongknowme.data.local.UserDatabase
 import com.dongyang.android.youdongknowme.data.local.entity.KeywordEntity
-import com.dongyang.android.youdongknowme.data.repository.*
+import com.dongyang.android.youdongknowme.data.repository.AlarmRepository
+import com.dongyang.android.youdongknowme.data.repository.CafeteriaRepository
+import com.dongyang.android.youdongknowme.data.repository.DepartRepository
+import com.dongyang.android.youdongknowme.data.repository.DetailRepository
+import com.dongyang.android.youdongknowme.data.repository.KeywordRepository
+import com.dongyang.android.youdongknowme.data.repository.NoticeRepository
+import com.dongyang.android.youdongknowme.data.repository.ScheduleRepository
+import com.dongyang.android.youdongknowme.data.repository.SettingRepository
+import com.dongyang.android.youdongknowme.data.repository.SplashRepository
 import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
 import com.dongyang.android.youdongknowme.ui.view.alarm.AlarmViewModel
 import com.dongyang.android.youdongknowme.ui.view.cafeteria.CafeteriaViewModel
@@ -125,13 +133,12 @@ val utilModule = module {
     }
 }
 
-private val defaultKeywordList = arrayListOf<KeywordEntity>(
+private val defaultKeywordList = arrayListOf(
     KeywordEntity("시험", "exam", false),
     KeywordEntity("수강", "course", false),
     KeywordEntity("특강", "lecture", false),
     KeywordEntity("계절학기", "season", false),
     KeywordEntity("장학", "scholarship", false),
-    KeywordEntity("국가장학", "kosaf", false),
     KeywordEntity("등록", "tuition", false),
     KeywordEntity("휴학", "leave", false),
     KeywordEntity("복학", "return", false),

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Mapping.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Mapping.kt
@@ -7,7 +7,6 @@ fun mapKeywordEnglishToKorean(english: String): String {
         "lecture" -> "특강"
         "season" -> "계절학기"
         "scholarship" -> "장학"
-        "kosaf" -> "국가장학"
         "tuition" -> "등록"
         "leave" -> "휴학"
         "return" -> "복학"

--- a/app/src/main/res/layout/activity_keyword.xml
+++ b/app/src/main/res/layout/activity_keyword.xml
@@ -13,8 +13,8 @@
             layout="@layout/standard_toolbar"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize"
-            app:title="@{@string/keyword_title}"
-            app:exitVisible="@{!vm.isFirstLaunch()}"/>
+            app:exitVisible="@{!vm.isFirstLaunch()}"
+            app:title="@{@string/keyword_title}" />
 
         <ScrollView
             android:id="@+id/keyword_scroll_view"
@@ -139,15 +139,6 @@
                             android:checkable="true"
                             android:checked="false"
                             android:text="@string/keyword_money_scholarship" />
-
-
-                        <com.google.android.material.chip.Chip
-                            style="@style/Colors_Widget.MaterialComponents.Chip.Choice"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:checkable="true"
-                            android:checked="false"
-                            android:text="@string/keyword_money_kosaf" />
 
                         <com.google.android.material.chip.Chip
                             style="@style/Colors_Widget.MaterialComponents.Chip.Choice"

--- a/app/src/main/res/layout/item_alarm.xml
+++ b/app/src/main/res/layout/item_alarm.xml
@@ -42,7 +42,7 @@
                     app:layout_constraintVertical_bias="0.3" />
 
                 <TextView
-                    android:id="@+id/item_alarm_deparmtent"
+                    android:id="@+id/item_alarm_department"
                     style="@style/PretendardBold12"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -61,7 +61,7 @@
                     android:background="@color/line"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/item_alarm_keyword"
-                    app:layout_constraintStart_toEndOf="@id/item_alarm_deparmtent"
+                    app:layout_constraintStart_toEndOf="@id/item_alarm_department"
                     app:layout_constraintTop_toBottomOf="@id/item_alarm_title"
                     app:layout_constraintVertical_bias="0.3" />
 
@@ -74,7 +74,7 @@
                     android:text="@{alarm.keyword}"
                     android:textColor="@color/main"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/item_alarm_deparmtent"
+                    app:layout_constraintStart_toEndOf="@id/item_alarm_department"
                     app:layout_constraintTop_toBottomOf="@id/item_alarm_title"
                     app:layout_constraintVertical_bias="0.25" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,6 @@
     <string name="keyword_class_season">계절학기</string>
     <string name="keyword_money">학자금</string>
     <string name="keyword_money_scholarship">장학</string>
-    <string name="keyword_money_kosaf">국가장학</string>
     <string name="keyword_money_tuition">등록</string>
     <string name="keyword_academic">학적</string>
     <string name="keyword_academic_leave">휴학</string>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #113 

## ✍️ 구현 내용
- 장학, 국가장학 키워드가 겹치는 요소가 많아 장학으로 통일

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
