### PR TITLE
Design : 식단 화면 리디자인

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaContainer.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaContainer.kt
@@ -36,15 +36,22 @@ class CafeteriaContainer(
         bind.itemCalendarDay.text = dayFormatter.format(day.date)
         bind.itemCalendarMonth.text = monthFormatter.format(day.date)
 
-        bind.itemCalendarDate.setTextColor(
-            ContextCompat.getColor(
-                view.context,
-                if (day.date == viewModel.selectedDate.value) {
-                    R.color.main
-                } else {
-                    R.color.black
-                }
+        if (day.date == viewModel.selectedDate.value) {
+            bind.mvItemCalendarDate.setCardBackgroundColor(
+                ContextCompat.getColor(
+                    view.context,
+                    R.color.blue300
+                )
             )
-        )
+            bind.itemCalendarDate.setTextColor(ContextCompat.getColor(view.context, R.color.white))
+        } else {
+            bind.mvItemCalendarDate.setCardBackgroundColor(
+                ContextCompat.getColor(
+                    view.context,
+                    R.color.white
+                )
+            )
+            bind.itemCalendarDate.setTextColor(ContextCompat.getColor(view.context, R.color.black))
+        }
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -1,6 +1,9 @@
 package com.dongyang.android.youdongknowme.ui.view.cafeteria
 
+import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.view.menu.MenuAdapter
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.window.layout.WindowMetricsCalculator
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentCafeteriaBinding
@@ -33,7 +36,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
         stuKoreanMenuAdapter = CafeteriaAdapter()
         stuAnotherMenuAdapter = CafeteriaAdapter()
 
-        binding.rvCafeteriaKoreanMenuList.apply {
+        binding.rvCafeteriaMenuList.apply {
             val layoutManager = FlexboxLayoutManager(context)
             layoutManager.flexDirection = FlexDirection.ROW
             this.adapter = this@CafeteriaFragment.stuKoreanMenuAdapter

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -26,18 +26,14 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
 
     private lateinit var stuKoreanMenuAdapter: CafeteriaAdapter
     private lateinit var stuAnotherMenuAdapter: CafeteriaAdapter
-    private lateinit var eduKoreanMenuAdapter: CafeteriaAdapter
-    private lateinit var eduAnotherMenuAdapter: CafeteriaAdapter
 
     override fun initStartView() {
         binding.vm = viewModel
 
         stuKoreanMenuAdapter = CafeteriaAdapter()
         stuAnotherMenuAdapter = CafeteriaAdapter()
-        eduKoreanMenuAdapter = CafeteriaAdapter()
-        eduAnotherMenuAdapter = CafeteriaAdapter()
 
-        binding.cafeteriaStuKoreanMenuList.apply {
+        binding.rvCafeteriaKoreanMenuList.apply {
             val layoutManager = FlexboxLayoutManager(context)
             layoutManager.flexDirection = FlexDirection.ROW
             this.adapter = this@CafeteriaFragment.stuKoreanMenuAdapter
@@ -45,7 +41,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             this.setHasFixedSize(true)
         }
 
-        binding.cafeteriaStuAnotherMenuList.apply {
+        binding.rvCafeteriaAnotherMenuList.apply {
             val layoutManager = FlexboxLayoutManager(context)
             layoutManager.flexDirection = FlexDirection.ROW
             this.adapter = this@CafeteriaFragment.stuAnotherMenuAdapter
@@ -53,35 +49,19 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             this.setHasFixedSize(true)
         }
 
-        binding.cafeteriaEduKoreanMenuList.apply {
-            val layoutManager = FlexboxLayoutManager(context)
-            layoutManager.flexDirection = FlexDirection.ROW
-            this.adapter = this@CafeteriaFragment.eduKoreanMenuAdapter
-            this.layoutManager = layoutManager
-            this.setHasFixedSize(true)
-        }
-
-        binding.cafeteriaEduAnotherMenuList.apply {
-            val layoutManager = FlexboxLayoutManager(context)
-            layoutManager.flexDirection = FlexDirection.ROW
-            this.adapter = this@CafeteriaFragment.eduAnotherMenuAdapter
-            this.layoutManager = layoutManager
-            this.setHasFixedSize(true)
-        }
-
         val wmc =
             WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(requireActivity())
 
-        binding.cafeteriaCalendar.apply {
+        binding.cvCafeteriaCalendar.apply {
             val dayWidth = wmc.bounds.width() / 5
             val dayHeight: Int = (dayWidth * 1.25).toInt()
 
             daySize = Size(dayWidth, dayHeight)
         }
 
-        binding.cafeteriaCalendar.dayBinder = object : DayBinder<CafeteriaContainer> {
+        binding.cvCafeteriaCalendar.dayBinder = object : DayBinder<CafeteriaContainer> {
             override fun create(view: View): CafeteriaContainer =
-                CafeteriaContainer(view, binding.cafeteriaCalendar, viewModel)
+                CafeteriaContainer(view, binding.cvCafeteriaCalendar, viewModel)
 
             override fun bind(container: CafeteriaContainer, day: CalendarDay) = container.bind(day)
         }
@@ -103,20 +83,16 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             stuAnotherMenuAdapter.submitList(it.second)
         }
 
-        viewModel.eduMenus.observe(viewLifecycleOwner) {
-            eduKoreanMenuAdapter.submitList(it.first)
-            eduAnotherMenuAdapter.submitList(it.second)
-        }
     }
 
     override fun initAfterBinding() {
-        binding.cafeteriaCalendar.setup(
+        binding.cvCafeteriaCalendar.setup(
             YearMonth.now().minusMonths(2),
             YearMonth.now().plusMonths(1),
             DayOfWeek.values().random()
         )
 
-        binding.cafeteriaCalendar.scrollToDate(LocalDate.now().minusDays(2))
+        binding.cvCafeteriaCalendar.scrollToDate(LocalDate.now().minusDays(2))
 
         binding.cafeteriaErrorContainer.refresh.setOnClickListener {
             viewModel.fetchCafeteria()
@@ -127,7 +103,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
         super.onPause()
         notifyDateChanged(
             viewModel,
-            binding.cafeteriaCalendar,
+            binding.cvCafeteriaCalendar,
             viewModel.selectedDate.value,
             LocalDate.now()
         )

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -36,9 +36,6 @@ class CafeteriaViewModel(
     private val _stuMenus: MutableLiveData<Pair<List<String>, List<String>>> = MutableLiveData()
     val stuMenus: LiveData<Pair<List<String>, List<String>>> = _stuMenus
 
-    private val _eduMenus: MutableLiveData<Pair<List<String>, List<String>>> = MutableLiveData()
-    val eduMenus: LiveData<Pair<List<String>, List<String>>> = _eduMenus
-
     init {
         fetchCafeteria()
     }
@@ -77,12 +74,7 @@ class CafeteriaViewModel(
             it.date == selectedDate && it.restaurant == resourceProvider.getString(R.string.cafeteria_student) && it.menuContent != "-"
         }?.menuContent ?: ""
 
-        val eduMenu = cafeteriaList.find {
-            it.date == selectedDate && it.restaurant == resourceProvider.getString(R.string.cafeteria_employee) && it.menuContent != "-"
-        }?.menuContent ?: ""
-
         _stuMenus.value = parsingMenu(stuMenu)
-        _eduMenus.value = parsingMenu(eduMenu)
     }
 
     private fun parsingMenu(menu: String): Pair<List<String>, List<String>> {

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -50,6 +50,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
+                    android:gravity="center"
                     android:paddingHorizontal="16dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -62,7 +63,7 @@
 
                     <TextView
                         android:id="@+id/tv_cafeteria_info_place"
-                        style="@style/PretendardRegular12"
+                        style="@style/PretendardRegular14"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
@@ -78,7 +79,7 @@
 
                     <TextView
                         android:id="@+id/tv_cafeteria_info_time"
-                        style="@style/PretendardRegular12"
+                        style="@style/PretendardRegular14"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -49,8 +49,8 @@
                     android:id="@+id/cafeteria_info_container"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
                     android:gravity="center"
+                    android:orientation="horizontal"
                     android:paddingHorizontal="16dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -108,20 +108,24 @@
                 </LinearLayout>
 
                 <com.google.android.material.card.MaterialCardView
+<<<<<<< Updated upstream
                     android:id="@+id/mv_cafeteria_korean"
+=======
+                    android:id="@+id/rv_cafeteria_menu"
+>>>>>>> Stashed changes
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="12dp"
-                    android:background="@color/main"
+                    android:outlineSpotShadowColor="@color/blue300"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
+                    app:layout_constraintBottom_toTopOf="@id/mv_cafeteria_another"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container"
-                    app:layout_constraintBottom_toTopOf="@id/mv_cafeteria_another">
+                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -144,11 +148,15 @@
                             android:layout_marginStart="8dp"
                             android:layout_marginTop="8dp"
                             tools:listitem="@layout/item_cafeteria_menu" />
+<<<<<<< Updated upstream
+=======
+
+
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 
                 <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/mv_cafeteria_another"
+                    android:id="@+id/rv_cafeteria_another_menu"
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
                     android:layout_width="0dp"
@@ -160,7 +168,52 @@
                     app:cardElevation="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            style="@style/PretendardBold14"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="16dp"
+                            android:layout_marginTop="12dp"
+                            android:text="@string/cafeteria_another"
+                            android:textColor="@color/black" />
+
+                        <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/cafeteria_stu_another_menu_list"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:layout_marginTop="8dp"
+                            tools:listitem="@layout/item_cafeteria_menu" />
+>>>>>>> Stashed changes
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/mv_cafeteria_another"
+                    bind_is_error="@{vm.cafeteriaList == null}"
+                    bind_is_loading="@{vm.isLoading()}"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="20dp"
+                    android:outlineSpotShadowColor="@color/blue300"
+                    app:cardCornerRadius="16dp"
+                    app:cardElevation="8dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+<<<<<<< Updated upstream
                     app:layout_constraintTop_toBottomOf="@id/mv_cafeteria_korean">
+=======
+                    app:layout_constraintTop_toBottomOf="@id/cafeteria_stu_menu_container">
+>>>>>>> Stashed changes
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -198,7 +198,6 @@
                     android:outlineSpotShadowColor="@color/blue300"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/mv_cafeteria_korean">

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -115,6 +115,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="12dp"
+                    android:outlineSpotShadowColor="@color/blue300"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -140,7 +141,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="8dp"
-                            android:layout_marginTop="8dp"
+                            android:layout_marginVertical="8dp"
                             tools:listitem="@layout/item_cafeteria_menu" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
@@ -179,7 +180,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="8dp"
-                            android:layout_marginTop="8dp"
+                            android:layout_marginVertical="8dp"
                             tools:listitem="@layout/item_cafeteria_menu" />
 
                     </LinearLayout>

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -51,7 +51,7 @@
                     android:layout_height="wrap_content"
                     android:gravity="center"
                     android:orientation="horizontal"
-                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="16dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cv_cafeteria_calendar">

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -108,11 +108,7 @@
                 </LinearLayout>
 
                 <com.google.android.material.card.MaterialCardView
-<<<<<<< Updated upstream
                     android:id="@+id/mv_cafeteria_korean"
-=======
-                    android:id="@+id/rv_cafeteria_menu"
->>>>>>> Stashed changes
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
                     android:layout_width="0dp"
@@ -148,9 +144,6 @@
                             android:layout_marginStart="8dp"
                             android:layout_marginTop="8dp"
                             tools:listitem="@layout/item_cafeteria_menu" />
-<<<<<<< Updated upstream
-=======
-
 
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
@@ -191,7 +184,6 @@
                             android:layout_marginStart="8dp"
                             android:layout_marginTop="8dp"
                             tools:listitem="@layout/item_cafeteria_menu" />
->>>>>>> Stashed changes
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 
@@ -209,11 +201,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-<<<<<<< Updated upstream
                     app:layout_constraintTop_toBottomOf="@id/mv_cafeteria_korean">
-=======
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_stu_menu_container">
->>>>>>> Stashed changes
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -108,17 +108,15 @@
                 </LinearLayout>
 
                 <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/mv_cafeteria_korean"
+                    android:id="@+id/mv_cafeteria_menu"
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="12dp"
-                    android:outlineSpotShadowColor="@color/blue300"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
-                    app:layout_constraintBottom_toTopOf="@id/mv_cafeteria_another"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container">
@@ -138,47 +136,7 @@
                             android:textColor="@color/black" />
 
                         <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/rv_cafeteria_korean_menu_list"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="8dp"
-                            android:layout_marginTop="8dp"
-                            tools:listitem="@layout/item_cafeteria_menu" />
-
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/rv_cafeteria_another_menu"
-                    bind_is_error="@{vm.cafeteriaList == null}"
-                    bind_is_loading="@{vm.isLoading()}"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="16dp"
-                    android:layout_marginTop="12dp"
-                    android:background="@color/main"
-                    app:cardCornerRadius="16dp"
-                    app:cardElevation="8dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            style="@style/PretendardBold14"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="16dp"
-                            android:layout_marginTop="12dp"
-                            android:text="@string/cafeteria_another"
-                            android:textColor="@color/black" />
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/cafeteria_stu_another_menu_list"
+                            android:id="@+id/rv_cafeteria_menu_list"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="8dp"
@@ -200,7 +158,7 @@
                     app:cardElevation="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/mv_cafeteria_korean">
+                    app:layout_constraintTop_toBottomOf="@id/mv_cafeteria_menu">
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -16,7 +16,7 @@
             app:title="@{@string/cafeteria_main}" />
 
         <androidx.core.widget.NestedScrollView
-            android:id="@+id/cafeteria_content_container"
+            android:id="@+id/nsv_cafeteria_content"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:fillViewport="true"
@@ -31,7 +31,7 @@
                 android:orientation="vertical">
 
                 <com.kizitonwose.calendarview.CalendarView
-                    android:id="@+id/cafeteria_calendar"
+                    android:id="@+id/cv_cafeteria_calendar"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:cv_dayViewResource="@layout/item_calendar_day"
@@ -53,7 +53,7 @@
                     android:paddingHorizontal="16dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_calendar">
+                    app:layout_constraintTop_toBottomOf="@id/cv_cafeteria_calendar">
 
                     <ImageView
                         android:layout_width="wrap_content"
@@ -61,7 +61,7 @@
                         android:src="@drawable/ic_location" />
 
                     <TextView
-                        android:id="@+id/cafeteria_info_place"
+                        android:id="@+id/tv_cafeteria_info_place"
                         style="@style/PretendardRegular12"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -77,7 +77,7 @@
                         android:src="@drawable/ic_timer" />
 
                     <TextView
-                        android:id="@+id/cafeteria_info_time"
+                        android:id="@+id/tv_cafeteria_info_time"
                         style="@style/PretendardRegular12"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -107,7 +107,7 @@
                 </LinearLayout>
 
                 <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cafeteria_stu_menu_container"
+                    android:id="@+id/mv_cafeteria_korean"
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
                     android:layout_width="0dp"
@@ -119,21 +119,13 @@
                     app:cardElevation="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container">
+                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container"
+                    app:layout_constraintBottom_toTopOf="@id/mv_cafeteria_another">
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
-
-                        <TextView
-                            style="@style/PretendardBold16"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="16dp"
-                            android:layout_marginTop="12dp"
-                            android:text="@string/cafeteria_student"
-                            android:textColor="@color/black" />
 
                         <TextView
                             style="@style/PretendardBold14"
@@ -145,80 +137,34 @@
                             android:textColor="@color/black" />
 
                         <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/cafeteria_stu_korean_menu_list"
+                            android:id="@+id/rv_cafeteria_korean_menu_list"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="8dp"
                             android:layout_marginTop="8dp"
                             tools:listitem="@layout/item_cafeteria_menu" />
-
-                        <TextView
-                            style="@style/PretendardBold14"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="16dp"
-                            android:layout_marginTop="12dp"
-                            android:text="@string/cafeteria_another"
-                            android:textColor="@color/black" />
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/cafeteria_stu_another_menu_list"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="8dp"
-                            android:layout_marginTop="8dp"
-                            tools:listitem="@layout/item_cafeteria_menu" />
-
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 
                 <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cafeteria_emp_menu_container"
+                    android:id="@+id/mv_cafeteria_another"
                     bind_is_error="@{vm.cafeteriaList == null}"
                     bind_is_loading="@{vm.isLoading()}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="12dp"
-                    android:layout_marginBottom="12dp"
                     android:background="@color/main"
                     app:cardCornerRadius="16dp"
                     app:cardElevation="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_stu_menu_container"
-                    app:layout_constraintBottom_toBottomOf="parent">
+                    app:layout_constraintTop_toBottomOf="@id/mv_cafeteria_korean">
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
-
-                        <TextView
-                            style="@style/PretendardBold16"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="16dp"
-                            android:layout_marginTop="12dp"
-                            android:text="@string/cafeteria_employee"
-                            android:textColor="@color/black" />
-
-                        <TextView
-                            style="@style/PretendardBold14"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="16dp"
-                            android:layout_marginTop="12dp"
-                            android:text="@string/cafeteria_korean"
-                            android:textColor="@color/black" />
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/cafeteria_edu_korean_menu_list"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="8dp"
-                            android:layout_marginTop="8dp"
-                            tools:listitem="@layout/item_cafeteria_menu" />
 
                         <TextView
                             style="@style/PretendardBold14"
@@ -230,7 +176,7 @@
                             android:textColor="@color/black" />
 
                         <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/cafeteria_edu_another_menu_list"
+                            android:id="@+id/rv_cafeteria_another_menu_list"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="8dp"
@@ -238,7 +184,6 @@
                             tools:listitem="@layout/item_cafeteria_menu" />
 
                     </LinearLayout>
-
                 </com.google.android.material.card.MaterialCardView>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -13,7 +13,7 @@
             layout="@layout/standard_toolbar"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize"
-            app:title="@{@string/cafeteria_main}" />
+            app:title="@{@string/cafeteria_title}" />
 
         <androidx.core.widget.NestedScrollView
             android:id="@+id/nsv_cafeteria_content"

--- a/app/src/main/res/layout/item_cafeteria_menu.xml
+++ b/app/src/main/res/layout/item_cafeteria_menu.xml
@@ -11,6 +11,7 @@
             style="@style/Colors_Widget.MaterialComponents.Chip"
             android:layout_width="wrap_content"
             android:layout_height="48dp"
+            android:backgroundTint="@color/blue100"
             android:clickable="false"
             android:text="@{menu, default = 해바라기멸치볶음}"
             android:textAlignment="center" />

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -29,15 +29,26 @@
                 android:textColor="@color/black"
                 tools:text="Jun" />
 
-            <TextView
-                android:id="@+id/item_calendar_date"
-                style="@style/PretendardRegular14"
-                android:layout_width="match_parent"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/mv_item_calendar_date"
+                android:layout_width="32dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
+                android:layout_gravity="center"
+                android:layout_marginTop="8dp"
                 android:gravity="center"
-                android:textColor="@color/black"
-                tools:text="16" />
+                app:cardElevation="0dp"
+                app:cardCornerRadius="10dp">
+
+                <TextView
+                    android:id="@+id/item_calendar_date"
+                    style="@style/PretendardRegular16"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:minHeight="32dp"
+                    android:textColor="@color/black"
+                    tools:text="16" />
+            </com.google.android.material.card.MaterialCardView>
 
             <TextView
                 android:id="@+id/item_calendar_day"
@@ -45,7 +56,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_marginTop="4dp"
+                android:layout_marginTop="8dp"
                 android:gravity="center"
                 android:textColor="@color/black"
                 tools:text="Mon" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,7 @@
     <string name="alarm_title">알림함</string>
 
     <!-- cafeteria -->
-    <string name="cafeteria_main">식단</string>
+    <string name="cafeteria_main">금주의 식단</string>
     <string name="cafeteria_student">학생식당</string>
     <string name="cafeteria_menu">메뉴</string>
     <string name="cafeteria_lunch">점심</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,14 +100,13 @@
     <!-- cafeteria -->
     <string name="cafeteria_main">식단</string>
     <string name="cafeteria_student">학생식당</string>
-    <string name="cafeteria_employee">교직원식당</string>
     <string name="cafeteria_menu">메뉴</string>
     <string name="cafeteria_lunch">점심</string>
-    <string name="cafeteria_time">11:30 ~ 14:00</string>
+    <string name="cafeteria_time">11:30 - 14:00, 16:30 - 18:00</string>
     <string name="cafeteria_place">8호관 3층</string>
     <string name="cafeteria_no_menu">&#128517; 등록된 메뉴가 없어요.</string>
     <string name="cafeteria_korean">🍚 한식</string>
-    <string name="cafeteria_another">😋 일품</string>
+    <string name="cafeteria_another">🍛 일품</string>
 
     <!-- license -->
     <string name="license_title">오픈소스 라이센스</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,8 @@
     <string name="alarm_title">알림함</string>
 
     <!-- cafeteria -->
-    <string name="cafeteria_main">금주의 식단</string>
+    <string name="cafeteria_main">식단</string>
+    <string name="cafeteria_title">금주의 식단</string>
     <string name="cafeteria_student">학생식당</string>
     <string name="cafeteria_menu">메뉴</string>
     <string name="cafeteria_lunch">점심</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,7 +15,7 @@
     </style>
 
     <style name="Colors_Widget.MaterialComponents.Chip" parent="Widget.MaterialComponents.Chip.Choice">
-        <item name="android:textAppearance">@style/PretendardRegular12</item>
+        <item name="android:textAppearance">@style/PretendardRegular14</item>
         <item name="android:textAlignment">center</item>
         <item name="android:textColor">@color/black</item>
     </style>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #152 

## ✍️ 구현 내용
- 식단 화면을 피그마 화면에 맞춰 리디자인하였습니다.
- 툴바의 텍스트를 '금주의 식단'으로 수정하였습니다.
- 날짜 선택 시 포커스의 배경색과 글자색의 변경을 디자인에 맞춰 수정하였습니다.
- 시간 정보를 디자인에 맞춰 수정하였습니다.
- 교직원의 식단을 제거하였습니다.
- 한식과 일품의 카드뷰를 분리하였습니다.
- 카드뷰의 그림자 색상을 추가하였습니다.
- 각 메뉴부의 바탕색을 수정하였습니다.
- 사용되는 이모티콘을 디자인에 맞춰 수정하였습니다.

## 📷 구현 영상
- 동적 움직임이 없어 사진으로 대체합니다.
- 출력되는 텍스트는 임의로 넣은 데이터입니다.
![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/bd4b94b7-43fd-4b75-8116-87c21e2a0349)

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
