### PR TITLE
Feat : 대학/학과 공지 뷰 api 연결 및 무한 스크롤 적용

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Notice.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Notice.kt
@@ -3,14 +3,14 @@ package com.dongyang.android.youdongknowme.data.remote.entity
 import com.google.gson.annotations.SerializedName
 
 data class Notice(
-    @SerializedName("num")
-    var num: Int,
     @SerializedName("title")
-    var title: String,
-    @SerializedName("writer")
-    var writer: String,
+    val title: String,
+    @SerializedName("author")
+    val author: String,
     @SerializedName("date")
-    var date: String,
+    val date: String,
+    @SerializedName("url")
+    val url: String,
 )
 
 data class NoticeDetail(

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/NoticeService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/NoticeService.kt
@@ -1,22 +1,14 @@
 package com.dongyang.android.youdongknowme.data.remote.service
 
 import com.dongyang.android.youdongknowme.data.remote.entity.Notice
-import com.dongyang.android.youdongknowme.data.remote.entity.NoticeDetail
-import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NoticeService {
-    @GET("/notice/{code}")
-    suspend fun getList(
-        @Path("code") code : Int
-    ) : List<Notice>
-
-    @GET("/notice/{code}/search")
-    suspend fun getSearchList(
-        @Path("code") code : Int,
-        @Query("keyword") keyword : String
-    ) : List<Notice>
+    @GET("api/v1/dmu/universityNotice")
+    suspend fun getUniversityNotice(
+        @Query("page") page: Int,
+        @Query("size") size: Int
+    ): List<Notice>
 }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/NoticeService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/NoticeService.kt
@@ -2,11 +2,19 @@ package com.dongyang.android.youdongknowme.data.remote.service
 
 import com.dongyang.android.youdongknowme.data.remote.entity.Notice
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NoticeService {
     @GET("api/v1/dmu/universityNotice")
     suspend fun getUniversityNotice(
+        @Query("page") page: Int,
+        @Query("size") size: Int
+    ): List<Notice>
+
+    @GET("api/v1/dmu/departmentNotice/{department}")
+    suspend fun getDepartmentNotice(
+        @Path("department") department: String,
         @Query("page") page: Int,
         @Query("size") size: Int
     ): List<Notice>

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/NoticeService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/NoticeService.kt
@@ -6,6 +6,7 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NoticeService {
+
     @GET("api/v1/dmu/universityNotice")
     suspend fun getUniversityNotice(
         @Query("page") page: Int,

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -1,5 +1,7 @@
 package com.dongyang.android.youdongknowme.data.repository
 
+import CODE
+import android.util.Log
 import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.data.local.dao.AlarmDao
 import com.dongyang.android.youdongknowme.data.remote.entity.Notice
@@ -8,18 +10,20 @@ import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
 import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 import kotlinx.coroutines.flow.Flow
-import retrofit2.Response
 
 class NoticeRepository(
     private val alarmDao: AlarmDao,
     private val errorResponseHandler: ErrorResponseHandler
 ) {
-    suspend fun fetchAllNotices(): NetworkResult<Map<String,List<Notice>>> {
+    suspend fun fetchAllNotices(): NetworkResult<Map<String, List<Notice>>> {
         return try {
-            val departNotices = RetrofitObject.getNetwork().create(NoticeService::class.java).getList(SharedPreference.getCode())
-            val schoolNotices = RetrofitObject.getNetwork().create(NoticeService::class.java).getList(CODE.SCHOOL_CODE)
+            val departNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
+                .getUniversityNotice(1, 20)
+            val schoolNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
+                .getUniversityNotice(1, 20)
 
-            val result : Map<String,List<Notice>> = mapOf("school" to schoolNotices, "depart" to departNotices)
+            val result: Map<String, List<Notice>> =
+                mapOf("school" to schoolNotices, "depart" to departNotices)
 
             NetworkResult.Success(result)
         } catch (exception: Exception) {
@@ -30,9 +34,11 @@ class NoticeRepository(
 
     suspend fun fetchNotices(code: Int): NetworkResult<List<Notice>> {
         return try {
-            val response = RetrofitObject.getNetwork().create(NoticeService::class.java).getList(code)
+            val response =
+                RetrofitObject.getNetwork().create(NoticeService::class.java).getUniversityNotice(1, 10)
             NetworkResult.Success(response)
         } catch (exception: Exception) {
+            Log.d("notice", exception.toString())
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }
@@ -40,7 +46,8 @@ class NoticeRepository(
 
     suspend fun fetchSearchNotices(code: Int, keyword: String): NetworkResult<List<Notice>> {
         return try {
-            val response = RetrofitObject.getNetwork().create(NoticeService::class.java).getSearchList(code, keyword)
+            val response = RetrofitObject.getNetwork().create(NoticeService::class.java)
+                .getSearchList(code, keyword)
             NetworkResult.Success(response)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -12,23 +12,22 @@ class NoticeRepository(
 ) {
     suspend fun fetchUniversityNotices(): NetworkResult<List<Notice>> {
         return try {
-            val universityNotice = RetrofitObject.getNetwork().create(NoticeService::class.java)
+            val universityNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
                 .getUniversityNotice(1, 20)
 
-            NetworkResult.Success(universityNotice)
+            NetworkResult.Success(universityNotices)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }
     }
 
-    suspend fun fetchNotices(code: Int): NetworkResult<List<Notice>> {
+    suspend fun fetchDepartmentNotices(department: String): NetworkResult<List<Notice>> {
         return try {
-            val response =
-                RetrofitObject.getNetwork().create(NoticeService::class.java)
-                    .getUniversityNotice(1, 10)
-            NetworkResult.Success(response)
-        } catch (exception: Exception) {
+            val departmentNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
+                .getDepartmentNotice(department, 1, 20)
+            NetworkResult.Success(departmentNotices)
+        }catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -1,29 +1,21 @@
 package com.dongyang.android.youdongknowme.data.repository
 
 import com.dongyang.android.youdongknowme.data.local.SharedPreference
-import com.dongyang.android.youdongknowme.data.local.dao.AlarmDao
 import com.dongyang.android.youdongknowme.data.remote.entity.Notice
 import com.dongyang.android.youdongknowme.data.remote.service.NoticeService
 import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
 import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
-import kotlinx.coroutines.flow.Flow
 
 class NoticeRepository(
-    private val alarmDao: AlarmDao,
     private val errorResponseHandler: ErrorResponseHandler
 ) {
-    suspend fun fetchAllNotices(): NetworkResult<Map<String, List<Notice>>> {
+    suspend fun fetchUniversityNotices(): NetworkResult<List<Notice>> {
         return try {
             val universityNotice = RetrofitObject.getNetwork().create(NoticeService::class.java)
                 .getUniversityNotice(1, 20)
-            val departNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getDepartmentNotice("기계공학과", 1, 20)
 
-            val result: Map<String, List<Notice>> =
-                mapOf("school" to universityNotice, "depart" to departNotices)
-
-            NetworkResult.Success(result)
+            NetworkResult.Success(universityNotice)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -1,6 +1,5 @@
 package com.dongyang.android.youdongknowme.data.repository
 
-import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.data.remote.entity.Notice
 import com.dongyang.android.youdongknowme.data.remote.service.NoticeService
 import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
@@ -27,11 +26,9 @@ class NoticeRepository(
             val departmentNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
                 .getDepartmentNotice(department, 1, 20)
             NetworkResult.Success(departmentNotices)
-        }catch (exception: Exception) {
+        } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }
     }
-
-    fun getDepartmentCode(): Int = SharedPreference.getCode()
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -9,10 +9,10 @@ import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 class NoticeRepository(
     private val errorResponseHandler: ErrorResponseHandler
 ) {
-    suspend fun fetchUniversityNotices(): NetworkResult<List<Notice>> {
+    suspend fun fetchUniversityNotices(page: Int): NetworkResult<List<Notice>> {
         return try {
             val universityNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getUniversityNotice(1, 20)
+                .getUniversityNotice(page, DEFAULT_SIZE)
 
             NetworkResult.Success(universityNotices)
         } catch (exception: Exception) {
@@ -30,5 +30,9 @@ class NoticeRepository(
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }
+    }
+
+    companion object {
+        private const val DEFAULT_SIZE = 20
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -1,7 +1,5 @@
 package com.dongyang.android.youdongknowme.data.repository
 
-import CODE
-import android.util.Log
 import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.data.local.dao.AlarmDao
 import com.dongyang.android.youdongknowme.data.remote.entity.Notice
@@ -17,13 +15,13 @@ class NoticeRepository(
 ) {
     suspend fun fetchAllNotices(): NetworkResult<Map<String, List<Notice>>> {
         return try {
+            val universityNotice = RetrofitObject.getNetwork().create(NoticeService::class.java)
+                .getUniversityNotice(1, 20)
             val departNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getUniversityNotice(1, 20)
-            val schoolNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getUniversityNotice(1, 20)
+                .getDepartmentNotice("기계공학과", 1, 20)
 
             val result: Map<String, List<Notice>> =
-                mapOf("school" to schoolNotices, "depart" to departNotices)
+                mapOf("school" to universityNotice, "depart" to departNotices)
 
             NetworkResult.Success(result)
         } catch (exception: Exception) {
@@ -35,27 +33,14 @@ class NoticeRepository(
     suspend fun fetchNotices(code: Int): NetworkResult<List<Notice>> {
         return try {
             val response =
-                RetrofitObject.getNetwork().create(NoticeService::class.java).getUniversityNotice(1, 10)
-            NetworkResult.Success(response)
-        } catch (exception: Exception) {
-            Log.d("notice", exception.toString())
-            val error = errorResponseHandler.getError(exception)
-            NetworkResult.Error(error)
-        }
-    }
-
-    suspend fun fetchSearchNotices(code: Int, keyword: String): NetworkResult<List<Notice>> {
-        return try {
-            val response = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getSearchList(code, keyword)
+                RetrofitObject.getNetwork().create(NoticeService::class.java)
+                    .getUniversityNotice(1, 10)
             NetworkResult.Success(response)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }
     }
-
-    fun getUnVisitedAlarmCount(): Flow<Int> = alarmDao.getUnVisitedAlarmCount()
 
     fun getDepartmentCode(): Int = SharedPreference.getCode()
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/NoticeRepository.kt
@@ -21,10 +21,10 @@ class NoticeRepository(
         }
     }
 
-    suspend fun fetchDepartmentNotices(department: String): NetworkResult<List<Notice>> {
+    suspend fun fetchDepartmentNotices(department: String, page: Int): NetworkResult<List<Notice>> {
         return try {
             val departmentNotices = RetrofitObject.getNetwork().create(NoticeService::class.java)
-                .getDepartmentNotice(department, 1, 20)
+                .getDepartmentNotice(department, page, DEFAULT_SIZE)
             NetworkResult.Success(departmentNotices)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -103,7 +103,7 @@ val viewModelModule = module {
 
 val repositoryModule = module {
     single {
-        NoticeRepository(get(), get())
+        NoticeRepository(get())
     }
     single {
         DetailRepository(get())

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/network/RetrofitObject.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/network/RetrofitObject.kt
@@ -13,7 +13,7 @@ object RetrofitObject {
 
     fun getNetwork(): Retrofit {
 
-        val baseUrl = "http://3.38.118.184:8000"
+        val baseUrl = "https://triphub.kr/"
 
         val baseInterceptor = Interceptor { chain ->
             val request = chain.request().newBuilder()

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/NoticeAdapter.kt
@@ -21,7 +21,6 @@ class NoticeAdapter : RecyclerView.Adapter<NoticeAdapter.ViewHolder>() {
         : RecyclerView.ViewHolder(binding.root) {
             fun bind(item : Notice) {
                 binding.notice = item
-                binding.itemClickListener = itemClickListener
             }
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/NoticeAdapter.kt
@@ -15,17 +15,10 @@ class NoticeAdapter : RecyclerView.Adapter<NoticeAdapter.ViewHolder>() {
     }
 
     private var noticeList = arrayListOf<Notice>()
-    private var itemClickListener : NoticeClickListener? = null
-
-    inner class ViewHolder(private val binding: ItemNoticeBinding)
-        : RecyclerView.ViewHolder(binding.root) {
-            fun bind(item : Notice) {
-                binding.notice = item
-            }
-    }
+    private var itemClickListener: NoticeClickListener? = null
 
     @SuppressLint("NotifyDataSetChanged")
-    fun submitList(item : List<Notice>) {
+    fun submitList(item: List<Notice>) {
         noticeList.clear()
         noticeList.addAll(item)
         notifyDataSetChanged()
@@ -49,7 +42,16 @@ class NoticeAdapter : RecyclerView.Adapter<NoticeAdapter.ViewHolder>() {
 
     override fun getItemCount(): Int = noticeList.size
 
-    fun setItemClickListener(listener : NoticeClickListener) {
+    fun setItemClickListener(listener: NoticeClickListener) {
         itemClickListener = listener
+    }
+
+    class ViewHolder(private val binding: ItemNoticeBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: Notice) {
+            binding.itemNoticeTitle.text = item.title
+            binding.itemNoticeDate.text = item.date
+            binding.itemNoticeAuthor.text = item.author
+        }
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/NoticeAdapter.kt
@@ -48,10 +48,11 @@ class NoticeAdapter : RecyclerView.Adapter<NoticeAdapter.ViewHolder>() {
 
     class ViewHolder(private val binding: ItemNoticeBinding) :
         RecyclerView.ViewHolder(binding.root) {
+
         fun bind(item: Notice) {
-            binding.itemNoticeTitle.text = item.title
-            binding.itemNoticeDate.text = item.date
-            binding.itemNoticeAuthor.text = item.author
+            binding.tvNoticeTitle.text = item.title
+            binding.tvNoticeDate.text = item.date
+            binding.tvNoticeAuthor.text = item.author
         }
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -63,7 +63,6 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
     }
 
     override fun initAfterBinding() {
-        viewModel.getUnVisitedAlarmCount()
 
         binding.noticeSwipe.setOnRefreshListener {
             viewModel.refreshNotices()

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -105,7 +105,12 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
                 val totalItemCount = layoutManager.itemCount
 
                 if (!viewModel.isLoading.value!! && lastVisibleItemPosition >= totalItemCount - 1) {
-                    viewModel.fetchUniversityNotices()
+                    viewModel.selectedTab.value?.peekContent()?.let { currentTab ->
+                        when (currentTab) {
+                            NoticeTabType.FACULTY -> viewModel.fetchDepartmentNotices()
+                            NoticeTabType.SCHOOL -> viewModel.fetchUniversityNotices()
+                        }
+                    }
                 }
             }
         })

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -3,6 +3,7 @@ package com.dongyang.android.youdongknowme.ui.view.notice
 import android.content.Intent
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentNoticeBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
@@ -29,6 +30,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
             this.addItemDecoration(DividerItemDecoration(requireContext(), 1))
         }
         setupTabLayout()
+        setupInfinityScroll()
     }
 
     override fun initDataBinding() {
@@ -91,6 +93,22 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
     private fun setupTabLayout() {
         if (viewModel.selectedTab.value?.peekContent() == NoticeTabType.FACULTY)
             binding.noticeTab.getTabAt(1)?.select()
+    }
+
+    private fun setupInfinityScroll() {
+        binding.noticeRvList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+
+                val layoutManager = recyclerView.layoutManager as LinearLayoutManager
+                val lastVisibleItemPosition = layoutManager.findLastCompletelyVisibleItemPosition()
+                val totalItemCount = layoutManager.itemCount
+
+                if (!viewModel.isLoading.value!! && lastVisibleItemPosition >= totalItemCount - 1) {
+                    viewModel.fetchUniversityNotices()
+                }
+            }
+        })
     }
 
     override fun itemClick(num: Int) {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -12,7 +12,6 @@ import com.dongyang.android.youdongknowme.ui.view.util.EventObserver
 import com.google.android.material.tabs.TabLayout
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-/* 공지 사항 화면 */
 class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), NoticeClickListener {
 
     override val layoutResourceId: Int = R.layout.fragment_notice
@@ -59,7 +58,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
     override fun initAfterBinding() {
 
         binding.noticeSwipe.setOnRefreshListener {
-//            viewModel.refreshNotices()
+            viewModel.refreshNotices()
             binding.noticeSwipe.isRefreshing = false
         }
 
@@ -68,10 +67,13 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
 
                 binding.noticeRvList.scrollToPosition(0)
 
-                if (tab.text == getString(R.string.notice_tab_university))
+                if (tab.text == getString(R.string.notice_tab_university)) {
+                    viewModel.updateSelectedTabType(NoticeTabType.SCHOOL)
                     viewModel.fetchUniversityNotices()
-                else
+                } else {
+                    viewModel.updateSelectedTabType(NoticeTabType.FACULTY)
                     viewModel.fetchDepartmentNotices()
+                }
             }
 
             override fun onTabUnselected(tab: TabLayout.Tab?) {}
@@ -82,7 +84,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
         })
 
         binding.noticeErrorContainer.refresh.setOnClickListener {
-//            viewModel.refreshNotices()
+            viewModel.fetchUniversityNotices()
         }
     }
 
@@ -92,10 +94,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
     }
 
     override fun itemClick(num: Int) {
-        val departCode = viewModel.departmentCode.value
-
         val intent = Intent(requireContext(), DetailActivity::class.java)
-        intent.putExtra("departCode", departCode)
         intent.putExtra("boardNum", num)
         startActivity(intent)
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -15,7 +15,6 @@ import com.dongyang.android.youdongknowme.standard.util.ACTION
 import com.dongyang.android.youdongknowme.ui.adapter.NoticeAdapter
 import com.dongyang.android.youdongknowme.ui.view.detail.DetailActivity
 import com.dongyang.android.youdongknowme.ui.view.util.EventObserver
-import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.tabs.TabLayout
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -24,10 +23,6 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
 
     override val layoutResourceId: Int = R.layout.fragment_notice
     override val viewModel: NoticeViewModel by viewModel()
-
-    private val badgeDrawable: BadgeDrawable by lazy {
-        BadgeDrawable.create(requireActivity())
-    }
 
     private lateinit var adapter: NoticeAdapter
 
@@ -70,13 +65,11 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
     override fun initAfterBinding() {
         viewModel.getUnVisitedAlarmCount()
 
-        // 새로고침 했을 때 동작
         binding.noticeSwipe.setOnRefreshListener {
             viewModel.refreshNotices()
             binding.noticeSwipe.isRefreshing = false
         }
 
-        // 각각 탭 버튼 눌렀을 때 동작
         binding.noticeTab.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
 
@@ -90,7 +83,6 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
 
             override fun onTabUnselected(tab: TabLayout.Tab?) {}
 
-            // 다시 클릭시 스크롤되게 설정
             override fun onTabReselected(tab: TabLayout.Tab?) {
                 binding.noticeRvList.smoothScrollToPosition(-10)
             }
@@ -118,7 +110,6 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
         LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(localBroadCast)
     }
 
-    // 아이템 클릭시 자세히 보기 화면으로 이동
     override fun itemClick(num: Int) {
         val departCode = viewModel.departmentCode.value
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeFragment.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.util.Log
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -28,24 +29,22 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
 
     private val localBroadCast = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            viewModel.refreshNotices()
+//            viewModel.refreshNotices()
         }
     }
 
     override fun initStartView() {
-        binding.vm = viewModel
         adapter = NoticeAdapter().apply { setItemClickListener(this@NoticeFragment) }
         binding.noticeRvList.apply {
             this.adapter = this@NoticeFragment.adapter
             this.layoutManager = LinearLayoutManager(requireActivity())
             this.itemAnimator = null
             this.setHasFixedSize(true)
-            this.addItemDecoration(DividerItemDecoration(requireActivity(), 1))
+            this.addItemDecoration(DividerItemDecoration(requireContext(), 1))
         }
         setupTabLayout()
     }
 
-    @SuppressLint("UnsafeOptInUsageError")
     override fun initDataBinding() {
 
         viewModel.isLoading.observe(viewLifecycleOwner) {
@@ -53,7 +52,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
             else dismissLoading()
         }
 
-        viewModel.noticeList.observe(viewLifecycleOwner) {
+        viewModel.universityNotices.observe(viewLifecycleOwner) {
             adapter.submitList(it)
         }
 
@@ -65,7 +64,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
     override fun initAfterBinding() {
 
         binding.noticeSwipe.setOnRefreshListener {
-            viewModel.refreshNotices()
+//            viewModel.refreshNotices()
             binding.noticeSwipe.isRefreshing = false
         }
 
@@ -88,7 +87,7 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>(), N
         })
 
         binding.noticeErrorContainer.refresh.setOnClickListener {
-            viewModel.refreshNotices()
+//            viewModel.refreshNotices()
         }
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
@@ -31,9 +31,6 @@ class NoticeViewModel(
     private val _departmentCode: MutableLiveData<Int> = MutableLiveData()
     val departmentCode: LiveData<Int> = _departmentCode
 
-    private val _isSearchMode: MutableLiveData<Boolean> = MutableLiveData()
-    val isSearchMode: LiveData<Boolean> = _isSearchMode
-
     private val _universityNoticeList: MutableLiveData<List<Notice>> = MutableLiveData()
 
     private val _facultyNoticeList: MutableLiveData<List<Notice>> = MutableLiveData()
@@ -41,23 +38,17 @@ class NoticeViewModel(
     private val _noticeList: MutableLiveData<List<Notice>> = MutableLiveData()
     val noticeList: LiveData<List<Notice>> = _noticeList
 
-    private val _unVisitedAlarmCount: MutableLiveData<Int> = MutableLiveData()
-    val unVisitedAlarmCount: LiveData<Int> = _unVisitedAlarmCount
-
     init {
         updateSelectedTabType(NoticeTabType.SCHOOL)
-        updateSearchMode(false)
     }
 
-    // 선택한 탭에 대한 데이터 저장
     fun updateSelectedTabType(tabType: NoticeTabType) {
         _selectedTab.value = Event(tabType)
         setDepartmentCode()
     }
 
-    // 선택 학부에 따라 보여지는 공지사항이 달라지게 설정
     private fun setDepartmentCode() {
-        if (selectedTab.value?.peekContent() == NoticeTabType.SCHOOL) { // 대학 공지사항 탭 클릭시 대학 공지사항이 보이게 설정
+        if (selectedTab.value?.peekContent() == NoticeTabType.SCHOOL) {
             _departmentCode.value = CODE.SCHOOL_CODE
         } else {
             _departmentCode.value = noticeRepository.getDepartmentCode()
@@ -65,7 +56,6 @@ class NoticeViewModel(
         fetchNotices()
     }
 
-    // 공지사항 리스트 호출
     private fun fetchNotices() {
         // 비어있을 때만 새로 갱신
         val universityNoticeList = _universityNoticeList.value ?: emptyList()
@@ -85,6 +75,7 @@ class NoticeViewModel(
                                 _universityNoticeList.value = noticeList
                                 _noticeList.postValue(noticeList)
                             }
+
                             else -> {
                                 _facultyNoticeList.value = noticeList
                                 _noticeList.postValue(noticeList)
@@ -93,6 +84,7 @@ class NoticeViewModel(
                         _isError.postValue(false)
                         _isLoading.postValue(false)
                     }
+
                     is NetworkResult.Error -> {
                         handleError(result, _errorState)
                         _isError.postValue(true)
@@ -124,6 +116,7 @@ class NoticeViewModel(
                         CODE.SCHOOL_CODE -> {
                             _noticeList.postValue(noticeMap["school"])
                         }
+
                         else -> {
                             _noticeList.postValue(noticeMap["depart"])
                         }
@@ -131,48 +124,12 @@ class NoticeViewModel(
                     _isError.postValue(false)
                     _isLoading.postValue(false)
                 }
+
                 is NetworkResult.Error -> {
                     handleError(result, _errorState)
                     _isError.postValue(true)
                     _isLoading.postValue(false)
                 }
-            }
-        }
-    }
-
-    // 검색어가 포함된 공지사항 리스트 호출
-    fun fetchSearchNotices(keyword: String) {
-        _isLoading.postValue(true)
-
-        viewModelScope.launch {
-            when (val result = noticeRepository.fetchSearchNotices(
-                departmentCode.value ?: DEFAULT_VALUE,
-                keyword
-            )) {
-                is NetworkResult.Success -> {
-                    val searchList = result.data
-                    _noticeList.postValue(searchList)
-                    _isError.postValue(false)
-                    _isLoading.postValue(false)
-                }
-                is NetworkResult.Error -> {
-                    handleError(result, _errorState)
-                    _isError.postValue(true)
-                    _isLoading.postValue(false)
-                }
-            }
-        }
-    }
-
-    // 검색 모드 활성화 상태 체크
-    fun updateSearchMode(value: Boolean) {
-        _isSearchMode.postValue(value)
-    }
-
-    fun getUnVisitedAlarmCount() {
-        viewModelScope.launch {
-            noticeRepository.getUnVisitedAlarmCount().collect { count ->
-                _unVisitedAlarmCount.postValue(count)
             }
         }
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
@@ -1,6 +1,5 @@
 package com.dongyang.android.youdongknowme.ui.view.notice
 
-import CODE
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
@@ -11,7 +10,6 @@ import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.ui.view.util.Event
 import kotlinx.coroutines.launch
 
-/* 공지사항 뷰모델 */
 class NoticeViewModel(
     private val noticeRepository: NoticeRepository
 ) : BaseViewModel() {
@@ -28,14 +26,11 @@ class NoticeViewModel(
     private val _selectedTab: MutableLiveData<Event<NoticeTabType>> = MutableLiveData()
     val selectedTab: LiveData<Event<NoticeTabType>> = _selectedTab
 
-    private val _departmentCode: MutableLiveData<Int> = MutableLiveData()
-    val departmentCode: LiveData<Int> = _departmentCode
+    private val _universityNotices: MutableLiveData<List<Notice>?> = MutableLiveData()
+    val universityNotices: LiveData<List<Notice>?> = _universityNotices
 
-    private val _universityNotices = MutableLiveData<List<Notice>?>()
-    val universityNotices : LiveData<List<Notice>?> get() = _universityNotices
-
-    private val _departmentNotices = MutableLiveData<List<Notice>?>()
-    val departmentNotices : LiveData<List<Notice>?> get() = _departmentNotices
+    private val _departmentNotices: MutableLiveData<List<Notice>?> = MutableLiveData()
+    val departmentNotices: LiveData<List<Notice>?> = _departmentNotices
 
     init {
         updateSelectedTabType(NoticeTabType.SCHOOL)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/notice/NoticeViewModel.kt
@@ -77,9 +77,10 @@ class NoticeViewModel(
         _isLoading.postValue(true)
 
         viewModelScope.launch {
-            when (val result =
-                noticeRepository.fetchDepartmentNotices("컴퓨터소프트웨어공학과", departmentNoticeCurrentPage)) {
-                    is NetworkResult.Success -> {
+            when (val result = noticeRepository.fetchDepartmentNotices(
+                "컴퓨터소프트웨어공학과", departmentNoticeCurrentPage
+            )) {
+                is NetworkResult.Success -> {
                     val updatedNotices = _departmentNotices.value.orEmpty() + result.data
                     _departmentNotices.postValue(updatedNotices)
                     _isError.postValue(false)
@@ -87,7 +88,7 @@ class NoticeViewModel(
                     departmentNoticeCurrentPage++
                 }
 
-                    is NetworkResult.Error -> {
+                is NetworkResult.Error -> {
                     handleError(result, _errorState)
                     _isError.postValue(true)
                     _isLoading.postValue(false)
@@ -100,40 +101,40 @@ class NoticeViewModel(
         _isLoading.postValue(true)
         _selectedTab.value?.peekContent()?.let { currentTab ->
             when (currentTab) {
-                NoticeTabType.SCHOOL ->
-                    viewModelScope.launch {
-                        when (val result =
-                            noticeRepository.fetchUniversityNotices(DEFAULT_REFRESH_PAGE)) {
-                            is NetworkResult.Success -> {
-                                _universityNotices.value = result.data
-                                _isError.postValue(false)
-                                _isLoading.postValue(false)
-                            }
+                NoticeTabType.SCHOOL -> viewModelScope.launch {
+                    when (val result =
+                        noticeRepository.fetchUniversityNotices(DEFAULT_REFRESH_PAGE)) {
+                        is NetworkResult.Success -> {
+                            _universityNotices.value = result.data
+                            _isError.postValue(false)
+                            _isLoading.postValue(false)
+                        }
 
-                            is NetworkResult.Error -> {
-                                handleError(result, _errorState)
-                                _isError.postValue(true)
-                                _isLoading.postValue(false)
-                            }
+                        is NetworkResult.Error -> {
+                            handleError(result, _errorState)
+                            _isError.postValue(true)
+                            _isLoading.postValue(false)
                         }
                     }
+                }
 
-                NoticeTabType.FACULTY ->
-                    viewModelScope.launch {
-                        when (val result = noticeRepository.fetchDepartmentNotices("컴퓨터소프트웨어공학과", DEFAULT_REFRESH_PAGE)) {
-                            is NetworkResult.Success -> {
-                                _departmentNotices.value = result.data
-                                _isError.postValue(false)
-                                _isLoading.postValue(false)
-                            }
+                NoticeTabType.FACULTY -> viewModelScope.launch {
+                    when (val result = noticeRepository.fetchDepartmentNotices(
+                        "컴퓨터소프트웨어공학과", DEFAULT_REFRESH_PAGE
+                    )) {
+                        is NetworkResult.Success -> {
+                            _departmentNotices.value = result.data
+                            _isError.postValue(false)
+                            _isLoading.postValue(false)
+                        }
 
-                            is NetworkResult.Error -> {
-                                handleError(result, _errorState)
-                                _isError.postValue(true)
-                                _isLoading.postValue(false)
-                            }
+                        is NetworkResult.Error -> {
+                            handleError(result, _errorState)
+                            _isError.postValue(true)
+                            _isLoading.postValue(false)
                         }
                     }
+                }
             }
         }
     }

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -66,7 +66,7 @@
                     android:id="@+id/notice_tab_faculty"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/notice_tab_faculty" />
+                    android:text="@string/notice_tab_department" />
 
             </com.google.android.material.tabs.TabLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -109,7 +109,7 @@
         </ScrollView>
 
         <ScrollView
-            bind_is_error="@{!vm.noticeList.empty}"
+            bind_is_error="@{!vm.universityNotices.empty}"
             bind_is_loading="@{vm.isLoading()}"
             android:layout_width="0dp"
             android:layout_height="0dp"

--- a/app/src/main/res/layout/item_notice.xml
+++ b/app/src/main/res/layout/item_notice.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/item_notice_container"
@@ -16,7 +17,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:paddingTop="20dp"
-            android:text="@{notice.title}"
+            tools:hint="2024학년도 1학기 수강신청 안내"
             android:textColor="@color/black"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -29,8 +30,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:maxLines="1"
+            tools:hint="2024.02.22"
             android:paddingBottom="20dp"
-            android:text="@{notice.date}"
             android:textColor="@color/gray400"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/item_notice_author"
@@ -44,7 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:maxLines="1"
-            android:text="@{notice.author}"
+            tools:hint="박재선"
             android:textColor="@color/gray400"
             app:layout_constraintStart_toEndOf="@id/item_notice_date"
             app:layout_constraintTop_toTopOf="@id/item_notice_date" />
@@ -57,11 +58,4 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <data>
-
-        <variable
-            name="notice"
-            type="com.dongyang.android.youdongknowme.data.remote.entity.Notice" />
-    </data>
 </layout>

--- a/app/src/main/res/layout/item_notice.xml
+++ b/app/src/main/res/layout/item_notice.xml
@@ -7,8 +7,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/selectableItemBackground"
-        android:backgroundTint="@color/white"
-        android:onClick="@{() -> itemClickListener.itemClick(notice.num)}">
+        android:backgroundTint="@color/white">
 
         <TextView
             android:id="@+id/item_notice_title"
@@ -34,18 +33,18 @@
             android:text="@{notice.date}"
             android:textColor="@color/gray400"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/item_notice_writer"
+            app:layout_constraintEnd_toStartOf="@id/item_notice_author"
             app:layout_constraintStart_toStartOf="@id/item_notice_title"
             app:layout_constraintTop_toBottomOf="@id/item_notice_title" />
 
         <TextView
-            android:id="@+id/item_notice_writer"
+            android:id="@+id/item_notice_author"
             style="@style/PretendardRegular12"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:maxLines="1"
-            android:text="@{notice.writer}"
+            android:text="@{notice.author}"
             android:textColor="@color/gray400"
             app:layout_constraintStart_toEndOf="@id/item_notice_date"
             app:layout_constraintTop_toTopOf="@id/item_notice_date" />
@@ -64,10 +63,5 @@
         <variable
             name="notice"
             type="com.dongyang.android.youdongknowme.data.remote.entity.Notice" />
-
-        <variable
-            name="itemClickListener"
-            type="com.dongyang.android.youdongknowme.ui.view.notice.NoticeClickListener" />
-
     </data>
 </layout>

--- a/app/src/main/res/layout/item_notice.xml
+++ b/app/src/main/res/layout/item_notice.xml
@@ -4,14 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/item_notice_container"
+        android:id="@+id/cl_notice_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/selectableItemBackground"
         android:backgroundTint="@color/white">
 
         <TextView
-            android:id="@+id/item_notice_title"
+            android:id="@+id/tv_notice_title"
             style="@style/PretendardMedium16"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -24,7 +24,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/item_notice_date"
+            android:id="@+id/tv_notice_date"
             style="@style/PretendardRegular12"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -34,12 +34,12 @@
             android:paddingBottom="20dp"
             android:textColor="@color/gray400"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/item_notice_author"
-            app:layout_constraintStart_toStartOf="@id/item_notice_title"
-            app:layout_constraintTop_toBottomOf="@id/item_notice_title" />
+            app:layout_constraintEnd_toStartOf="@id/tv_notice_author"
+            app:layout_constraintStart_toStartOf="@id/tv_notice_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_notice_title" />
 
         <TextView
-            android:id="@+id/item_notice_author"
+            android:id="@+id/tv_notice_author"
             style="@style/PretendardRegular12"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -47,8 +47,8 @@
             android:maxLines="1"
             tools:hint="박재선"
             android:textColor="@color/gray400"
-            app:layout_constraintStart_toEndOf="@id/item_notice_date"
-            app:layout_constraintTop_toTopOf="@id/item_notice_date" />
+            app:layout_constraintStart_toEndOf="@id/tv_notice_date"
+            app:layout_constraintTop_toTopOf="@id/tv_notice_date" />
 
         <View
             android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <!-- notice -->
     <string name="notice_title">공지사항</string>
     <string name="notice_tab_university">대학 공지</string>
-    <string name="notice_tab_faculty">학부 공지</string>
+    <string name="notice_tab_faculty">학과 공지</string>
     <string name="notice_search_message">검색어를 입력해주세요.</string>
 
     <!-- detail -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <!-- notice -->
     <string name="notice_title">공지사항</string>
     <string name="notice_tab_university">대학 공지</string>
-    <string name="notice_tab_faculty">학과 공지</string>
+    <string name="notice_tab_department">학과 공지</string>
     <string name="notice_search_message">검색어를 입력해주세요.</string>
 
     <!-- detail -->


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #164 

## ✍️ 구현 내용
- 대학/학과 공지 api 연결했습니다.
- 각 공지에 무한 스크롤 적용했습니다. (로딩 뷰 적용)
- 캐싱 작업은 앱이 실행되어 있는 동안 적용 되어있습니다. > 추후 수정해보겠습니다.
- `데이터 바인딩`을 제거하고 `뷰바인딩` 적용했습니다. 

## 📷 구현 영상
- 
[Screen_recording_20240223_220356.webm](https://github.com/TeamDMU/DMU-Android/assets/114990782/a97f8d3a-f1a7-4867-b62d-bf362636253a)


## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
