### PR TITLE
Feat : 웹 뷰 파일 다운로드 구현

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
@@ -116,7 +116,7 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>() {
     }
 
     companion object {
-        const val KEY_URL = "url"
+        private const val KEY_URL = "url"
 
         fun newIntent(context: Context, url: String): Intent {
             return Intent(context, DetailActivity::class.java).apply {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
 import android.webkit.CookieManager
 import android.webkit.WebChromeClient
@@ -39,7 +38,8 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>() {
             setDownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
                 try {
                     val request = DownloadManager.Request(Uri.parse(url))
-                    val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+                    val downloadManager =
+                        getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
 
                     val fileName = URLDecoder.decode(contentDisposition, "UTF-8")
                         .replace("attachment; filename=", "")
@@ -72,7 +72,11 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>() {
                     )
 
                     downloadManager.enqueue(request)
-                    Toast.makeText(applicationContext, R.string.detail_download_description, Toast.LENGTH_LONG).show()
+                    Toast.makeText(
+                        applicationContext,
+                        R.string.detail_download_description,
+                        Toast.LENGTH_LONG
+                    ).show()
                 } catch (e: Exception) {
                     if (ContextCompat.checkSelfPermission(
                             applicationContext,
@@ -85,7 +89,11 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>() {
                             1004
                         )
                     } else {
-                        Toast.makeText(baseContext, R.string.detail_download_permission, Toast.LENGTH_LONG)
+                        Toast.makeText(
+                            baseContext,
+                            R.string.detail_download_permission,
+                            Toast.LENGTH_LONG
+                        )
                             .show()
                     }
                 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/detail/DetailActivity.kt
@@ -1,8 +1,12 @@
 package com.dongyang.android.youdongknowme.ui.view.detail
 
 import android.annotation.SuppressLint
+import android.app.DownloadManager
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.os.Environment
+import android.webkit.URLUtil
 import android.webkit.WebChromeClient
 import android.webkit.WebViewClient
 import com.dongyang.android.youdongknowme.R
@@ -24,6 +28,31 @@ class DetailActivity : BaseActivity<ActivityDetailBinding, DetailViewModel>() {
 
             webViewClient = WebViewClient()
             webChromeClient = WebChromeClient()
+
+            setDownloadListener { url, user, contentDisposition, mimetype, contentLength ->
+                val request = DownloadManager.Request(Uri.parse(url)).apply {
+                    // 다운로드에 대한 제목, 설명 설정
+                    setTitle(URLUtil.guessFileName(url, contentDisposition, mimetype))
+                    setDescription("Downloading file...")
+
+                    // 알림 표시줄에 다운로드 진행 상태 표시
+                    setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+
+                    // 파일 다운로드 경로 설정
+                    setDestinationInExternalPublicDir(
+                        Environment.DIRECTORY_DOWNLOADS,
+                        URLUtil.guessFileName(url, contentDisposition, mimetype)
+                    )
+
+                    // 모바일 네트워크 및 와이파이에서 다운로드 허용 설정
+                    setAllowedOverMetered(true)
+                    setAllowedOverRoaming(true)
+                }
+
+                // DownloadManager를 사용하여 다운로드 요청
+                val downloadManager = getSystemService(DOWNLOAD_SERVICE) as DownloadManager
+                downloadManager.enqueue(request)
+            }
 
             loadUrl(url.toString())
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="detail_download_description">다운로드를 진행 중입니다.</string>
     <string name="detail_download_fail">다운로드를 실패했습니다.\n다시 시도해주세요.</string>
     <string name="detail_download_success">파일 다운로드가 완료되었습니다.</string>
+    <string name="detail_download_permission">파일 다운로드 권한을 허용해주십시오.</string>
     <string name="detail_write_permission_dialog_title">파일 접근 권한 허용을 거부하였습니다.</string>
     <string name="detail_write_permission_dialog_message">파일을 다운로드 하기 위해서는 접근 권한이 필요합니다. 권한을 허용하시겠습니까?</string>
     <string name="detail_write_permission_dialog_ok">설정</string>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #169 

## ✍️ 구현 내용
- 웹 뷰에서의 첨부파일을 클릭했을 시 다운로드 받아지지 않던 이슈 해결했습니다.
- `DownloadListener` 자체를 지원해줘서 그 코드 사용했고, 코드 설명을 주석으로 달아놓았습니다.
- 머지되지 않은 브랜치를 사용해야 해서 rebase를 했더니 다른 브랜치의 기존 커밋 내역이 남아있습니다.

- ## 📷 구현 영상
[Screen_recording_20240225_152311.webm](https://github.com/TeamDMU/DMU-Android/assets/114990782/b67f1616-3fa5-4697-a7f6-201af2bdfdcb)


## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
