### PR TITLE
Hotfix  : 식단 주말 안내 제거

### DIFF
--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -108,21 +108,6 @@
                         android:layout_gravity="center" />
                 </LinearLayout>
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_weekend_cafeteria"
-                    style="@style/Colors_Widget.MaterialComponents.Chip"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:backgroundTint="@color/blue100"
-                    android:clickable="false"
-                    android:text="@string/cafetria_weekend"
-                    android:textAlignment="center"
-                    android:visibility="invisible"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/cafeteria_info_container" />
-
                 <com.google.android.material.card.MaterialCardView
                     android:id="@+id/mv_cafeteria_menu"
                     bind_is_error="@{vm.cafeteriaList == null}"


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #207 

## ✍️ 구현 내용
- 식단 화면 내 주말 안내 `string` 제거로 인한 미사용 뷰 제거

## 📷 구현 영상
- 구현 영상은 없습니다.

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
