### PR TITLE
Feat : 학과 설정 진입시 이전 학과 활성화

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/DepartRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/DepartRepository.kt
@@ -10,4 +10,8 @@ class DepartRepository {
         SharedPreference.setCode(department.code)
     }
     fun getIsFirstLaunch(): Boolean = SharedPreference.getIsFirstLaunch()
+
+    fun getUserDepartment(): String {
+        return SharedPreference.getDepartment()
+    }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/DepartAdapter.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/DepartAdapter.kt
@@ -14,7 +14,7 @@ import com.dongyang.android.youdongknowme.ui.view.depart.DepartClickListener
 
 class DepartAdapter : RecyclerView.Adapter<DepartAdapter.ViewHolder>() {
 
-    private var item = ArrayList<String>()
+    private val item = ArrayList<String>()
     private var itemClickListener: DepartClickListener? = null
     private var currentPosition = -1
     private var beforePosition = -1
@@ -47,11 +47,6 @@ class DepartAdapter : RecyclerView.Adapter<DepartAdapter.ViewHolder>() {
 
             }
         }
-    }
-
-    fun setItems(list: ArrayList<String>) {
-        this.item = list
-        notifyDataSetChanged()
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/DepartAdapter.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/adapter/DepartAdapter.kt
@@ -14,7 +14,7 @@ import com.dongyang.android.youdongknowme.ui.view.depart.DepartClickListener
 
 class DepartAdapter : RecyclerView.Adapter<DepartAdapter.ViewHolder>() {
 
-    private val item = ArrayList<String>()
+    private var item = ArrayList<String>()
     private var itemClickListener: DepartClickListener? = null
     private var currentPosition = -1
     private var beforePosition = -1
@@ -47,6 +47,11 @@ class DepartAdapter : RecyclerView.Adapter<DepartAdapter.ViewHolder>() {
 
             }
         }
+    }
+
+    fun setItems(list: ArrayList<String>) {
+        this.item = list
+        notifyDataSetChanged()
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartActivity.kt
@@ -36,7 +36,11 @@ class DepartActivity : BaseActivity<ActivityDepartBinding, DepartViewModel>(), D
 
     }
 
-    override fun initDataBinding() = Unit
+    override fun initDataBinding() {
+        viewModel.myDepartment.observe(this) { department ->
+            viewModel.setSelectPosition(items.indexOf(department))
+        }
+    }
 
     override fun initAfterBinding() {
         viewModel.selectDepartPosition.observe(this) {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartViewModel.kt
@@ -10,8 +10,19 @@ class DepartViewModel(private val departRepository: DepartRepository) : BaseView
     private val _isFirstLaunch: MutableLiveData<Boolean> = MutableLiveData(false)
     val isFirstLaunch: LiveData<Boolean> get() = _isFirstLaunch
 
+    private val _myDepartment: MutableLiveData<String> = MutableLiveData()
+    val myDepartment: LiveData<String> get() = _myDepartment
+
     private val _selectDepartPosition = MutableLiveData(-1)
     val selectDepartPosition: LiveData<Int> get() = _selectDepartPosition
+    init {
+        getUserDepartment()
+    }
+
+    fun getUserDepartment() {
+        val myDepartment = departRepository.getUserDepartment()
+        _myDepartment.postValue(myDepartment)
+    }
 
     fun setDepartment(department: String) {
         departRepository.setDepartment(department)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartViewModel.kt
@@ -19,7 +19,7 @@ class DepartViewModel(private val departRepository: DepartRepository) : BaseView
         getUserDepartment()
     }
 
-    fun getUserDepartment() {
+    private fun getUserDepartment() {
         val myDepartment = departRepository.getUserDepartment()
         _myDepartment.postValue(myDepartment)
     }


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #204 

## ✍️ 구현 내용
- 설정 화면에서 학과 화면으로 이동 시 기존에 선택한 학과가 활성화된 상태로 표시됩니다.
- `feature/setting-depart` 브랜치에서 작업하였으나 #210 과 #211 의 커밋이 섞여 새로운 브랜치를 작성하였습니다.

## 📷 구현 영상
https://github.com/TeamDMU/DMU-Android/assets/84004687/cbd9fc68-5fe4-4a32-a6c1-674b4590c448

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
