### PR TITLE
Feat : 설정화면 fcm 토큰 관련 api 연동

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/SharedPreference.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/SharedPreference.kt
@@ -37,25 +37,24 @@ object SharedPreference {
     // 최초 접속 여부
     private const val FIRST_LAUNCH = "FIRST_LAUNCH"
     fun getIsFirstLaunch(): Boolean = pref?.getBoolean(FIRST_LAUNCH, true) ?: true
-    fun setIsFirstLaunch(isFirstLaunch: Boolean) = pref?.edit()?.putBoolean(FIRST_LAUNCH, isFirstLaunch)?.apply()
+    fun setIsFirstLaunch(isFirstLaunch: Boolean) =
+        pref?.edit()?.putBoolean(FIRST_LAUNCH, isFirstLaunch)?.apply()
 
     // 학교 알림 설정 여부
     private const val ACCESS_SCHOOL_ALARM = "ACCESS_SCHOOL_ALARM"
     fun getIsAccessSchoolAlarm(): Boolean = pref?.getBoolean(ACCESS_SCHOOL_ALARM, true) ?: true
-    fun setIsAccessSchoolAlarm(isAccessSchoolAlarm: Boolean) = pref?.edit()?.putBoolean(ACCESS_SCHOOL_ALARM, isAccessSchoolAlarm)?.apply()
+    fun setIsAccessSchoolAlarm(isAccessSchoolAlarm: Boolean) =
+        pref?.edit()?.putBoolean(ACCESS_SCHOOL_ALARM, isAccessSchoolAlarm)?.apply()
 
     // 학과 알림 설정 여부
     private const val ACCESS_DEPART_ALARM = "ACCESS_DEPART_ALARM"
     fun getIsAccessDepartAlarm(): Boolean = pref?.getBoolean(ACCESS_DEPART_ALARM, true) ?: true
-    fun setIsAccessDepartAlarm(isAccessDepartAlarm: Boolean) = pref?.edit()?.putBoolean(ACCESS_DEPART_ALARM, isAccessDepartAlarm)?.apply()
+    fun setIsAccessDepartAlarm(isAccessDepartAlarm: Boolean) =
+        pref?.edit()?.putBoolean(ACCESS_DEPART_ALARM, isAccessDepartAlarm)?.apply()
 
     // FCM 토큰
-    private const val FCM_TOKEN = "FCM_TOKEN"
-    fun saveFcmToken(context: Context, token: String) {
-        getInstance(context).setFcmToken(token)
-    }
+    private const val FCM_TOKEN = "NO_TOKEN"
+    fun getFCMToken(): String = pref?.getString(FCM_TOKEN, "0") ?: "0"
+    fun setFcmToken(token: String) = pref?.edit()?.putString(FCM_TOKEN, token)?.apply()
 
-    private fun setFcmToken(token: String) {
-        pref?.edit()?.putString(FCM_TOKEN, token)?.apply()
-    }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/SharedPreference.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/SharedPreference.kt
@@ -49,4 +49,13 @@ object SharedPreference {
     fun getIsAccessDepartAlarm(): Boolean = pref?.getBoolean(ACCESS_DEPART_ALARM, true) ?: true
     fun setIsAccessDepartAlarm(isAccessDepartAlarm: Boolean) = pref?.edit()?.putBoolean(ACCESS_DEPART_ALARM, isAccessDepartAlarm)?.apply()
 
+    // FCM 토큰
+    private const val FCM_TOKEN = "FCM_TOKEN"
+    fun saveFcmToken(context: Context, token: String) {
+        getInstance(context).setFcmToken(token)
+    }
+
+    private fun setFcmToken(token: String) {
+        pref?.edit()?.putString(FCM_TOKEN, token)?.apply()
+    }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/local/dao/KeywordDao.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/local/dao/KeywordDao.kt
@@ -23,4 +23,7 @@ interface KeywordDao {
 
     @Query("DELETE FROM keyword WHERE name = :name")
     suspend fun deleteKeyword(name: String)
+
+    @Query("SELECT * FROM keyword WHERE isSubscribe = 1")
+    suspend fun getSubscribedKeywords(): List<KeywordEntity>
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Setting.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Setting.kt
@@ -5,6 +5,11 @@ data class UpdateDepartment(
     val department: String,
 )
 
-data class RemoveDepartment(
+data class RemoveToken(
     val token: String,
+)
+
+data class UpdateTopic(
+    val token: String,
+    val topics: List<String>,
 )

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Setting.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/entity/Setting.kt
@@ -1,0 +1,10 @@
+package com.dongyang.android.youdongknowme.data.remote.entity
+
+data class UpdateDepartment(
+    val token: String,
+    val department: String,
+)
+
+data class RemoveDepartment(
+    val token: String,
+)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/SettingService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/SettingService.kt
@@ -1,0 +1,15 @@
+package com.dongyang.android.youdongknowme.data.remote.service
+
+import com.dongyang.android.youdongknowme.data.remote.entity.RemoveDepartment
+import com.dongyang.android.youdongknowme.data.remote.entity.UpdateDepartment
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface SettingService {
+
+    @POST("department/v1/dmu/updateDepartment")
+    suspend fun updateDepartment(@Body data: UpdateDepartment)
+
+    @POST("department/v1/dmu/deleteDepartment")
+    suspend fun deleteDepartment(@Body token: RemoveDepartment)
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/SettingService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/remote/service/SettingService.kt
@@ -1,7 +1,8 @@
 package com.dongyang.android.youdongknowme.data.remote.service
 
-import com.dongyang.android.youdongknowme.data.remote.entity.RemoveDepartment
+import com.dongyang.android.youdongknowme.data.remote.entity.RemoveToken
 import com.dongyang.android.youdongknowme.data.remote.entity.UpdateDepartment
+import com.dongyang.android.youdongknowme.data.remote.entity.UpdateTopic
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -11,5 +12,11 @@ interface SettingService {
     suspend fun updateDepartment(@Body data: UpdateDepartment)
 
     @POST("department/v1/dmu/deleteDepartment")
-    suspend fun deleteDepartment(@Body token: RemoveDepartment)
+    suspend fun deleteDepartment(@Body token: RemoveToken)
+
+    @POST("token/v1/dmu/updateTopic")
+    suspend fun updateTopic(@Body data: UpdateTopic)
+
+    @POST("token/v1/dmu/deleteTopic")
+    suspend fun deleteTopic(@Body token: RemoveToken)
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/SettingRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/SettingRepository.kt
@@ -1,8 +1,16 @@
 package com.dongyang.android.youdongknowme.data.repository
 
 import com.dongyang.android.youdongknowme.data.local.SharedPreference
+import com.dongyang.android.youdongknowme.data.remote.entity.RemoveDepartment
+import com.dongyang.android.youdongknowme.data.remote.entity.UpdateDepartment
+import com.dongyang.android.youdongknowme.data.remote.service.SettingService
+import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
+import com.dongyang.android.youdongknowme.standard.network.NetworkResult
+import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 
-class SettingRepository {
+class SettingRepository(
+    private val errorResponseHandler: ErrorResponseHandler
+) {
 
     fun getIsAccessSchoolAlarm(): Boolean = SharedPreference.getIsAccessSchoolAlarm()
 
@@ -18,5 +26,35 @@ class SettingRepository {
 
     fun getUserDepartment(): String {
         return SharedPreference.getDepartment()
+    }
+
+    fun getUserFCMToken(): String {
+        return SharedPreference.getFCMToken()
+    }
+
+    suspend fun updateUserDepartment(
+        data: UpdateDepartment
+    ): NetworkResult<Unit> {
+        return try {
+            val response = RetrofitObject.getNetwork().create(SettingService::class.java)
+                .updateDepartment(data)
+            NetworkResult.Success(response)
+        } catch (exception: Exception) {
+            val error = errorResponseHandler.getError(exception)
+            NetworkResult.Error(error)
+        }
+    }
+
+    suspend fun removeUserDepartment(
+        token: RemoveDepartment
+    ): NetworkResult<Unit> {
+        return try {
+            val response = RetrofitObject.getNetwork().create(SettingService::class.java)
+                .deleteDepartment(token)
+            NetworkResult.Success(response)
+        } catch (exception: Exception) {
+            val error = errorResponseHandler.getError(exception)
+            NetworkResult.Error(error)
+        }
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/SettingRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/SettingRepository.kt
@@ -1,18 +1,21 @@
 package com.dongyang.android.youdongknowme.data.repository
 
 import com.dongyang.android.youdongknowme.data.local.SharedPreference
-import com.dongyang.android.youdongknowme.data.remote.entity.RemoveDepartment
+import com.dongyang.android.youdongknowme.data.local.dao.KeywordDao
+import com.dongyang.android.youdongknowme.data.remote.entity.RemoveToken
 import com.dongyang.android.youdongknowme.data.remote.entity.UpdateDepartment
+import com.dongyang.android.youdongknowme.data.remote.entity.UpdateTopic
 import com.dongyang.android.youdongknowme.data.remote.service.SettingService
 import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
 import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 
 class SettingRepository(
+    private val keywordDao: KeywordDao,
     private val errorResponseHandler: ErrorResponseHandler
 ) {
 
-    fun getIsAccessSchoolAlarm(): Boolean = SharedPreference.getIsAccessSchoolAlarm()
+    fun getIsAccessUniversityAlarm(): Boolean = SharedPreference.getIsAccessSchoolAlarm()
 
     fun getIsAccessDepartAlarm(): Boolean = SharedPreference.getIsAccessDepartAlarm()
 
@@ -26,6 +29,11 @@ class SettingRepository(
 
     fun getUserDepartment(): String {
         return SharedPreference.getDepartment()
+    }
+
+    suspend fun getUserTopic(): List<String> {
+        val subscribedTopic = keywordDao.getSubscribedKeywords()
+        return subscribedTopic.map { it.englishName }
     }
 
     fun getUserFCMToken(): String {
@@ -46,11 +54,37 @@ class SettingRepository(
     }
 
     suspend fun removeUserDepartment(
-        token: RemoveDepartment
+        token: RemoveToken
     ): NetworkResult<Unit> {
         return try {
             val response = RetrofitObject.getNetwork().create(SettingService::class.java)
                 .deleteDepartment(token)
+            NetworkResult.Success(response)
+        } catch (exception: Exception) {
+            val error = errorResponseHandler.getError(exception)
+            NetworkResult.Error(error)
+        }
+    }
+
+    suspend fun updateUserTopic(
+        data: UpdateTopic
+    ): NetworkResult<Unit> {
+        return try {
+            val response = RetrofitObject.getNetwork().create(SettingService::class.java)
+                .updateTopic(data)
+            NetworkResult.Success(response)
+        } catch (exception: Exception) {
+            val error = errorResponseHandler.getError(exception)
+            NetworkResult.Error(error)
+        }
+    }
+
+    suspend fun removeUserTopic(
+        token: RemoveToken
+    ): NetworkResult<Unit> {
+        return try {
+            val response = RetrofitObject.getNetwork().create(SettingService::class.java)
+                .deleteTopic(token)
             NetworkResult.Success(response)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/service/FCMService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/service/FCMService.kt
@@ -8,9 +8,11 @@ import android.content.Intent
 import android.media.RingtoneManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.ui.view.main.MainActivity
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import timber.log.Timber
 
 class FCMService : FirebaseMessagingService() {
 
@@ -58,5 +60,11 @@ class FCMService : FirebaseMessagingService() {
 
         // 알림 표시
         notificationManager.notify(System.currentTimeMillis().toInt(), builder.build())
+    }
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Timber.d("fcm_token_new: $token")
+        SharedPreference.saveFcmToken(this, token)
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/service/FCMService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/service/FCMService.kt
@@ -12,7 +12,6 @@ import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.ui.view.main.MainActivity
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import timber.log.Timber
 
 class FCMService : FirebaseMessagingService() {
 
@@ -64,7 +63,6 @@ class FCMService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        Timber.d("fcm_token_new: $token")
         SharedPreference.setFcmToken(token)
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/service/FCMService.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/service/FCMService.kt
@@ -65,6 +65,6 @@ class FCMService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         Timber.d("fcm_token_new: $token")
-        SharedPreference.saveFcmToken(this, token)
+        SharedPreference.setFcmToken(token)
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -117,7 +117,7 @@ val repositoryModule = module {
         KeywordRepository(get())
     }
     single {
-        SettingRepository(get())
+        SettingRepository(get(), get())
     }
     single {
         AlarmRepository(get())

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/di/KoinModules.kt
@@ -117,7 +117,7 @@ val repositoryModule = module {
         KeywordRepository(get())
     }
     single {
-        SettingRepository()
+        SettingRepository(get())
     }
     single {
         AlarmRepository(get())

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/network/RetrofitObject.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/network/RetrofitObject.kt
@@ -9,7 +9,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 object RetrofitObject {
-    private const val TIME_OUT_COUNT: Long = 10
+    private const val TIME_OUT_COUNT: Long = 30
 
     fun getNetwork(): Retrofit {
         val baseInterceptor = Interceptor { chain ->

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/DepartActivity.kt
@@ -64,9 +64,6 @@ class DepartActivity : BaseActivity<ActivityDepartBinding, DepartViewModel>(), D
     private fun getDepart(items: ArrayList<String>) {
         return binding.btnDepartComplete.setOnClickListener {
             viewModel.setDepartment(items[viewModel.selectDepartPosition.value ?: 0])
-            val intent = Intent(this, MainActivity::class.java)
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            startActivity(intent)
             finish()
         }
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/keyword/KeywordActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/keyword/KeywordActivity.kt
@@ -1,12 +1,10 @@
 package com.dongyang.android.youdongknowme.ui.view.keyword
 
-import android.content.Intent
 import androidx.lifecycle.Observer
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.data.local.entity.KeywordEntity
 import com.dongyang.android.youdongknowme.databinding.ActivityKeywordBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseActivity
-import com.dongyang.android.youdongknowme.ui.view.permission.OnboardingPermissionActivity
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -17,7 +15,7 @@ class KeywordActivity : BaseActivity<ActivityKeywordBinding, KeywordViewModel>()
     override val viewModel: KeywordViewModel by viewModel()
 
     override fun initStartView() = Unit
-    
+
     override fun initDataBinding() {
         // 효율을 위해 단 한번만 옵저빙하여 이미 구독중인 항목을 선택 처리
         viewModel.localKeywordList.observe(this, object : Observer<List<KeywordEntity>> {
@@ -40,14 +38,9 @@ class KeywordActivity : BaseActivity<ActivityKeywordBinding, KeywordViewModel>()
         viewModel.checkFirstLaunch()
         viewModel.getLocalKeywordList()
 
-        // TODO :: 안드로이드 데이터베이스에 유저별 설정한 키워드 저장 및 파이어베이스 키워드 구독 설정
         binding.btnKeywordComplete.setOnClickListener {
             viewModel.subscribeCheckedKeyword()
-            if (viewModel.isFirstLaunch.value == true) {
-                viewModel.setFirstLaunch(false)
-                val intent = Intent(this@KeywordActivity, OnboardingPermissionActivity::class.java)
-                startActivity(intent)
-            }
+            setResult(RESULT_OK)
             finish()
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/main/MainActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/main/MainActivity.kt
@@ -51,7 +51,7 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
 
             val token = task.result
             Timber.d("fcm_token: $token")
-            SharedPreference.saveFcmToken(this, token)
+            SharedPreference.setFcmToken(token)
         })
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/main/MainActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/main/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.plusAssign
 import androidx.navigation.ui.setupWithNavController
 import com.dongyang.android.youdongknowme.R
+import com.dongyang.android.youdongknowme.data.local.SharedPreference
 import com.dongyang.android.youdongknowme.databinding.ActivityMainBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseActivity
 import com.dongyang.android.youdongknowme.ui.view.util.KeepStateNavigator
@@ -38,9 +39,9 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
         getFcmToken()
     }
 
-    override fun initDataBinding() {}
+    override fun initDataBinding() = Unit
 
-    override fun initAfterBinding() {}
+    override fun initAfterBinding() = Unit
 
     private fun getFcmToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
@@ -49,9 +50,8 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
             }
 
             val token = task.result
-            Timber.d(token)
-            //TODO: prefs 선언 중복 제거될 경우 주석 제거
-            //prefs.edit().putString("fcm_token", token).commit()
+            Timber.d("fcm_token: $token")
+            SharedPreference.saveFcmToken(this, token)
         })
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/main/MainActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/main/MainActivity.kt
@@ -13,7 +13,6 @@ import com.dongyang.android.youdongknowme.ui.view.util.KeepStateNavigator
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.messaging.FirebaseMessaging
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import timber.log.Timber
 
 /* 메인 액티비티 */
 class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
@@ -50,7 +49,6 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
             }
 
             val token = task.result
-            Timber.d("fcm_token: $token")
             SharedPreference.setFcmToken(token)
         })
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/permission/OnboardingPermissionActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/permission/OnboardingPermissionActivity.kt
@@ -75,7 +75,7 @@ class OnboardingPermissionActivity :
         binding.mvSwitchPermission.strokeColor = getColor(resources)
 
         binding.switchPermission.isChecked = isChecked
-        viewModel.setIsAccessSchoolAlarm(isChecked)
+        viewModel.setIsAccessUniversityAlarm(isChecked)
         viewModel.setIsAccessDepartAlarm(isChecked)
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -1,7 +1,10 @@
 package com.dongyang.android.youdongknowme.ui.view.setting
 
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentSettingBinding
 import com.dongyang.android.youdongknowme.standard.base.BaseFragment
@@ -16,14 +19,22 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
     override val layoutResourceId: Int = R.layout.fragment_setting
     override val viewModel: SettingViewModel by viewModel()
 
+    private lateinit var resultLauncher: ActivityResultLauncher<Intent>
+    private var topics: List<String> = emptyList()
+
     override fun initStartView() {
         binding.tvSettingAppVersion.text = getAppVersion()
+        setResultKeyword()
     }
 
     override fun initDataBinding() {
 
         viewModel.myDepartment.observe(viewLifecycleOwner) { department ->
             binding.tvSettingDepartment.text = department
+        }
+
+        viewModel.myTopics.observe(viewLifecycleOwner) { myTopics ->
+            topics = myTopics
         }
 
         viewModel.isAccessUniversityAlarm.observe(viewLifecycleOwner) { isChecked ->
@@ -43,7 +54,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
 
         binding.switchSettingUniversityAlarm.setOnCheckedChangeListener { compoundButton, _ ->
             if (compoundButton.isChecked) {
-                viewModel.updateUserTopic()
+                viewModel.updateUserTopic(topics)
             } else {
                 viewModel.removeUserTopic()
             }
@@ -59,7 +70,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
 
         binding.btnSettingEditKeyword.setOnClickListener {
             val intent = Intent(requireActivity(), KeywordActivity::class.java)
-            startActivity(intent)
+            resultLauncher.launch(intent)
         }
 
         binding.btnSettingEditDepartment.setOnClickListener {
@@ -94,5 +105,15 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         val packageManager =
             requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
         return packageManager.versionName
+    }
+
+    private fun setResultKeyword() {
+        resultLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == Activity.RESULT_OK) {
+                    viewModel.getUserTopic()
+                    viewModel.updateUserTopic(topics)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -29,12 +29,12 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
 
     override fun initDataBinding() {
 
-        viewModel.myDepartment.observe(viewLifecycleOwner) { department ->
-            binding.tvSettingDepartment.text = department
+        viewModel.myDepartment.observe(viewLifecycleOwner) { myDepartment ->
+            binding.tvSettingDepartment.text = myDepartment
         }
 
         viewModel.myTopics.observe(viewLifecycleOwner) { myTopics ->
-            topics = myTopics
+            topics = topics
         }
 
         viewModel.isAccessUniversityAlarm.observe(viewLifecycleOwner) { isChecked ->

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -16,8 +16,6 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
     override val layoutResourceId: Int = R.layout.fragment_setting
     override val viewModel: SettingViewModel by viewModel()
 
-    private lateinit var FCMToken: String
-
     override fun initStartView() {
         binding.tvSettingAppVersion.text = getAppVersion()
     }
@@ -35,22 +33,19 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         viewModel.isAccessDepartAlarm.observe(viewLifecycleOwner) { isChecked ->
             binding.switchSettingDepartmentAlarm.isChecked = isChecked
         }
-
-        viewModel.FCMToken.observe(viewLifecycleOwner) { token ->
-            FCMToken = token
-        }
     }
 
     override fun initAfterBinding() {
 
         viewModel.checkAccessAlarm()
         viewModel.getUserDepartment()
+        viewModel.getUserTopic()
 
         binding.switchSettingUniversityAlarm.setOnCheckedChangeListener { compoundButton, _ ->
             if (compoundButton.isChecked) {
-                viewModel.setIsAccessSchoolAlarm(true)
+                viewModel.updateUserTopic()
             } else {
-                viewModel.setIsAccessSchoolAlarm(false)
+                viewModel.removeUserTopic()
             }
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -16,11 +16,14 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
     override val layoutResourceId: Int = R.layout.fragment_setting
     override val viewModel: SettingViewModel by viewModel()
 
+    private lateinit var FCMToken: String
+
     override fun initStartView() {
         binding.tvSettingAppVersion.text = getAppVersion()
     }
 
     override fun initDataBinding() {
+
         viewModel.myDepartment.observe(viewLifecycleOwner) { department ->
             binding.tvSettingDepartment.text = department
         }
@@ -32,9 +35,14 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         viewModel.isAccessDepartAlarm.observe(viewLifecycleOwner) { isChecked ->
             binding.switchSettingDepartmentAlarm.isChecked = isChecked
         }
+
+        viewModel.FCMToken.observe(viewLifecycleOwner) { token ->
+            FCMToken = token
+        }
     }
 
     override fun initAfterBinding() {
+
         viewModel.checkAccessAlarm()
         viewModel.getUserDepartment()
 
@@ -48,9 +56,9 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
 
         binding.switchSettingDepartmentAlarm.setOnCheckedChangeListener { compoundButton, _ ->
             if (compoundButton.isChecked) {
-                viewModel.setIsAccessDepartAlarm(true)
+                viewModel.updateUserDepartment()
             } else {
-                viewModel.setIsAccessDepartAlarm(false)
+                viewModel.removeUserDepartment()
             }
         }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingViewModel.kt
@@ -3,6 +3,7 @@ package com.dongyang.android.youdongknowme.ui.view.setting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import com.dongyang.android.youdongknowme.data.local.entity.KeywordEntity
 import com.dongyang.android.youdongknowme.data.remote.entity.RemoveToken
 import com.dongyang.android.youdongknowme.data.remote.entity.UpdateDepartment
 import com.dongyang.android.youdongknowme.data.remote.entity.UpdateTopic
@@ -34,8 +35,8 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
     private val _myDepartment: MutableLiveData<String> = MutableLiveData()
     val myDepartment: LiveData<String> get() = _myDepartment
 
-    private val _myTopic: MutableLiveData<List<String>> = MutableLiveData()
-    val myTopic: LiveData<List<String>> get() = _myTopic
+    private val _myTopics: MutableLiveData<List<String>> = MutableLiveData()
+    val myTopics: LiveData<List<String>> get() = _myTopics
 
     private val _FCMToken: MutableLiveData<String> = MutableLiveData()
     val FCMToken: LiveData<String> get() = _FCMToken
@@ -68,7 +69,7 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
     fun getUserTopic() {
         viewModelScope.launch {
             val keyword = settingRepository.getUserTopic()
-            _myTopic.value = keyword
+            _myTopics.value = keyword
         }
     }
 
@@ -124,13 +125,13 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
         }
     }
 
-    fun updateUserTopic() {
+    fun updateUserTopic(topic: List<String>) {
         _isLoading.postValue(true)
         viewModelScope.launch {
             when (val result = settingRepository.updateUserTopic(
                 UpdateTopic(
                     token = FCMToken.value.toString(),
-                    topics = myTopic.value ?: emptyList()
+                    topics = topic
                 )
             )) {
                 is NetworkResult.Success -> {
@@ -143,7 +144,6 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
                     handleError(result, _errorState)
                     _isLoading.postValue(false)
                     _isError.postValue(true)
-                    Timber.d("topic: ${UpdateTopic(FCMToken.value.toString(), myTopic.value?: emptyList())}")
                 }
             }
         }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingViewModel.kt
@@ -3,7 +3,6 @@ package com.dongyang.android.youdongknowme.ui.view.setting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.dongyang.android.youdongknowme.data.local.entity.KeywordEntity
 import com.dongyang.android.youdongknowme.data.remote.entity.RemoveToken
 import com.dongyang.android.youdongknowme.data.remote.entity.UpdateDepartment
 import com.dongyang.android.youdongknowme.data.remote.entity.UpdateTopic
@@ -12,7 +11,6 @@ import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
 import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.ui.view.util.Event
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 /* 설정 뷰모델 */
 class SettingViewModel(private val settingRepository: SettingRepository) : BaseViewModel() {
@@ -80,6 +78,7 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
 
     fun updateUserDepartment() {
         _isLoading.postValue(true)
+
         viewModelScope.launch {
             when (val result = settingRepository.updateUserDepartment(
                 UpdateDepartment(
@@ -104,6 +103,7 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
 
     fun removeUserDepartment() {
         _isLoading.postValue(true)
+
         viewModelScope.launch {
             when (val result =
                 settingRepository.removeUserDepartment(
@@ -127,6 +127,7 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
 
     fun updateUserTopic(topic: List<String>) {
         _isLoading.postValue(true)
+
         viewModelScope.launch {
             when (val result = settingRepository.updateUserTopic(
                 UpdateTopic(
@@ -151,6 +152,7 @@ class SettingViewModel(private val settingRepository: SettingRepository) : BaseV
 
     fun removeUserTopic() {
         _isLoading.postValue(true)
+        
         viewModelScope.launch {
             when (val result =
                 settingRepository.removeUserTopic(


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #175 

## ✍️ 구현 내용
- 스위치 알림 버튼 on/off가 api 구현에 따른 로직에 의해 반영되도록 수정했습니다.
- 학과 / 대학 공지 알림 off 시 delete api 연결했습니다.
- 학과 / 대학 공지 알림 on 시 update api 연결했습니다.
- 설정화면에서 학과 수정 시 메인으로 이동하는 로직을 `finish()`처리만 해서 다시 설정화면으로 돌아오도록 수정했습니다.
- 설정화면에서 키워드 액티비티 진입 후 완료 버튼 눌렀을 때 키워드 api 가 통신되도록 구현했습니다.

## 📷 구현 영상
<img width="840" alt="스크린샷 2024-03-30 오후 8 09 26" src="https://github.com/TeamDMU/DMU-Android/assets/114990782/7a32012d-d5a9-4ad2-a3f5-ca78306e5ccc">
서버 통신 200 로그로 구현 영상 대체합니다

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
