### PR TITLE
Design: 2차 QA 반영

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaContainer.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaContainer.kt
@@ -18,7 +18,7 @@ class CafeteriaContainer(
     private val bind = ItemCalendarDayBinding.bind(view)
     private lateinit var day: CalendarDay
 
-    private val dateFormatter = DateTimeFormatter.ofPattern("dd")
+    private val dateFormatter = DateTimeFormatter.ofPattern("d")
     private val dayFormatter = DateTimeFormatter.ofPattern("EEE")
     private val monthFormatter = DateTimeFormatter.ofPattern("MMM")
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -90,9 +90,8 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
         viewModel.menus.observe(viewLifecycleOwner) {
             koreanMenuAdapter.submitList(it)
             // 일품 메뉴 : 일품 메뉴는 리스트로 제작하여 등록
-            anotherMenuAdapter.submitList(listOf(getString(R.string.cafeteria_no_menu)))
+            anotherMenuAdapter.submitList(getString(R.string.cafeteria_another_list).split("/").map { it.trim() })
         }
-
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -1,6 +1,7 @@
 package com.dongyang.android.youdongknowme.ui.view.cafeteria
 
 import android.annotation.SuppressLint
+import android.util.TypedValue
 import android.view.MotionEvent
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
@@ -58,7 +59,11 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
 
         binding.cvCafeteriaCalendar.apply {
             val dayWidth = wmc.bounds.width() / 5
-            val dayHeight: Int = (dayWidth * 1.25).toInt()
+            val dayHeight: Int = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            124f,
+            resources.displayMetrics
+            ).toInt()
 
             daySize = Size(dayWidth, dayHeight)
         }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/OnboardingDepartActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/depart/OnboardingDepartActivity.kt
@@ -7,6 +7,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.ActivityOnboardingDepartBinding
@@ -67,8 +68,10 @@ class OnboardingDepartActivity : BaseActivity<ActivityOnboardingDepartBinding, D
 
                 if (searchText.isEmpty()) {
                     adapter.submitList(emptyList)
+                    binding.ibOnboardingDepartSearchClear.isVisible=false
                 } else {
                     // 검색 단어를 포함하는지 확인
+                    binding.ibOnboardingDepartSearchClear.isVisible=true
                     for (item in items) {
                         if (item.contains(searchText)) {
                             searchList.add(item)

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -4,10 +4,14 @@ import android.app.Activity
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.ColorStateList
 import android.net.Uri
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import android.os.Build
+import android.view.View
+import android.widget.Switch
+import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.ContextCompat
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentSettingBinding
@@ -64,7 +68,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         viewModel.getUserTopic()
 
         binding.switchSettingUniversityAlarm.setOnCheckedChangeListener { compoundButton, _ ->
-            checkPermission()
+            checkPermission(binding.switchSettingUniversityAlarm, binding.switchSettingUniversityAlarm.isChecked)
             if (compoundButton.isChecked) {
                 if (topics.isNotEmpty()) {
                     viewModel.updateUserTopic(topics)
@@ -75,7 +79,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         }
 
         binding.switchSettingDepartmentAlarm.setOnCheckedChangeListener { compoundButton, _ ->
-            checkPermission()
+            checkPermission(binding.switchSettingDepartmentAlarm, binding.switchSettingDepartmentAlarm.isChecked)
             if (compoundButton.isChecked) {
                 if (department.isNotEmpty()) {
                     viewModel.updateUserDepartment(department)
@@ -117,8 +121,8 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         }
     }
 
-    fun checkPermission(){
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    private fun checkPermission(switch: SwitchCompat, isChecked: Boolean){
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(
                     requireContext(), Manifest.permission.POST_NOTIFICATIONS
                 )
@@ -131,7 +135,11 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
 
                 val dialog = DialogPermission(getString(R.string.dialog_permission_title), getString(R.string.dialog_permission_content), requireContext().packageName)
                 dialog.show(parentFragmentManager, "CustomDialog")
+            } else {
+                switch.isChecked = isChecked
             }
+        } else {
+            switch.isChecked = isChecked
         }
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/setting/SettingFragment.kt
@@ -68,7 +68,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         viewModel.getUserTopic()
 
         binding.switchSettingUniversityAlarm.setOnCheckedChangeListener { compoundButton, _ ->
-            checkPermission(binding.switchSettingUniversityAlarm, binding.switchSettingUniversityAlarm.isChecked)
+            checkPermission(binding.switchSettingUniversityAlarm)
             if (compoundButton.isChecked) {
                 if (topics.isNotEmpty()) {
                     viewModel.updateUserTopic(topics)
@@ -79,7 +79,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         }
 
         binding.switchSettingDepartmentAlarm.setOnCheckedChangeListener { compoundButton, _ ->
-            checkPermission(binding.switchSettingDepartmentAlarm, binding.switchSettingDepartmentAlarm.isChecked)
+            checkPermission(binding.switchSettingDepartmentAlarm)
             if (compoundButton.isChecked) {
                 if (department.isNotEmpty()) {
                     viewModel.updateUserDepartment(department)
@@ -121,7 +121,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
         }
     }
 
-    private fun checkPermission(switch: SwitchCompat, isChecked: Boolean){
+    private fun checkPermission(switch: SwitchCompat){
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(
                     requireContext(), Manifest.permission.POST_NOTIFICATIONS
@@ -136,10 +136,10 @@ class SettingFragment : BaseFragment<FragmentSettingBinding, SettingViewModel>()
                 val dialog = DialogPermission(getString(R.string.dialog_permission_title), getString(R.string.dialog_permission_content), requireContext().packageName)
                 dialog.show(parentFragmentManager, "CustomDialog")
             } else {
-                switch.isChecked = isChecked
+                switch.isChecked = !switch.isChecked
             }
         } else {
-            switch.isChecked = isChecked
+            switch.isChecked = !switch.isChecked
         }
     }
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/splash/SplashActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/splash/SplashActivity.kt
@@ -82,7 +82,7 @@ class SplashActivity : BaseActivity<ActivitySplashBinding, SplashViewModel>() {
                 startActivity(intent)
                 finish()
             }
-        }else{
+        } else {
             val intent = OnboardingDepartActivity.createIntent(this@SplashActivity)
             startActivity(intent)
             finish()

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/splash/SplashActivity.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/splash/SplashActivity.kt
@@ -82,6 +82,10 @@ class SplashActivity : BaseActivity<ActivitySplashBinding, SplashViewModel>() {
                 startActivity(intent)
                 finish()
             }
+        }else{
+            val intent = OnboardingDepartActivity.createIntent(this@SplashActivity)
+            startActivity(intent)
+            finish()
         }
     }
 

--- a/app/src/main/res/color/bg_chip_select.xml
+++ b/app/src/main/res/color/bg_chip_select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="@color/blue300" android:state_checked="true" />
-    <item android:color="@color/transparent" />
+    <item android:color="@color/transparent" android:state_checked="false" />
 </selector>

--- a/app/src/main/res/layout/activity_onboarding_depart.xml
+++ b/app/src/main/res/layout/activity_onboarding_depart.xml
@@ -89,7 +89,8 @@
                 android:layout_marginHorizontal="16dp"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:src="@drawable/ic_close_black"
-                app:tint="@color/gray400" />
+                app:tint="@color/gray400"
+                android:visibility="invisible" />
         </LinearLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -20,6 +20,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:fillViewport="true"
+            android:layout_marginBottom="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="cafeteria_no_menu">&#128517; 등록된 메뉴가 없어요.</string>
     <string name="cafeteria_korean">🍚 한식</string>
     <string name="cafeteria_another">🍛 일품</string>
+    <string name="cafeteria_another_list">김치볶음밥 4,900원 / 라면 4,000원 / 치즈라면 4,500원 / 해물짬뽕라면 4,500원 / 돈가스 5,000원 / 치즈돈가스 5,500원 / 고구마치즈돈까스 6,000원</string>
 
     <!-- license -->
     <string name="license_title">오픈소스 라이센스</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,7 +13,7 @@
         <item name="chipStrokeColor">@color/bg_chip_stroke_select</item>
         <item name="chipStrokeWidth">1dp</item>
         <item name="android:textAlignment">center</item>
-        <item name="rippleColor">@color/blue300</item>
+        <item name="rippleColor">@null</item>
         <item name="chipMinTouchTargetSize">0dp</item>
         <item name="android:textColor">@color/bg_chip_text_select</item>
         <item name="chipCornerRadius">10dp</item>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #230 

## ✍️ 구현 내용
- 2차 QA 내용을 반영하였습니다.
**초기화면**
- `TIRAMISU` 버전 이하 일때 `Splash` 화면이 넘어가지 않는 오류를 수정하였습니다.
**온보딩/설정**
- 1단계의 학과 검색 시 내용이 없으면 취소 버튼이 비활성화 됩니다.
- 2단계와 설정의 키워드 선택에서 키워드 `chip`의 리플의 색상을 제거하였습니다.
- 설정 화면의 권한 설정의 `else` 처리를 하였습니다.
**식단**
- 날짜 출력 방식을 `dd` 방식에서 `d` 방식으로 수정하였습니다.
- 화면이 좁아질 경우 날짜 선택 부의 글씨가 잘리는 오류를 수정하였습니다.
- 일품의 식단 리스트를 추가하였습니다.
- 식단 화면의 하단 마진을 `20dp`를 추가하였습니다.

## 📷 구현 영상
**초기화면**
- 별도의 화면이 없습니다.

**온보딩 1단계 학과검색**
|검색 전|검색 중|검색 후|영상|
|---|---|---|---|
|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/febe667f-2984-4b61-8109-36fef57e6d95)|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/80c3c304-79dd-407e-b91b-fc87e2c02593)|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/125cf814-48ec-4234-82f8-2229aef584f9)|https://github.com/TeamDMU/DMU-Android/assets/84004687/c1fe8c04-b44e-47d9-9626-7264bc802687|

**키워드 리플 효과**
- 설정 화면과 동일하여 온보딩 2단계 영상만 첨부합니다.
https://github.com/TeamDMU/DMU-Android/assets/84004687/f63d9398-32cf-4e32-b016-867534000dab


**식단**
- 임의로 날짜를 조정하였습니다.

|한 자리 수|두 자리 수|좁은 화면|
|---|---|---|
|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/af1a3ab2-1482-4139-9715-556b2a9c9e5e)|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/edc97875-78ad-4788-800c-ccd348eb7dea)|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/c9cb9e37-f9dd-4546-b14f-b256cb1c34c3)|

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
