### PR TITLE
Refactor : 일품 및 빈 식단

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -68,7 +68,10 @@ class CafeteriaViewModel(
         val cafeteriaList = _cafeteriaList.value ?: emptyList()
         _selectedDate.value = selectedDate
         _menus.postValue(
-            cafeteriaList.find { it.date == selectedDate.toString() }?.menus ?: emptyMenu
+            cafeteriaList.find { it.date == selectedDate.toString() }?.menus
+                .takeIf { it.isNullOrEmpty() }
+                ?.let { emptyMenu }
+                ?: cafeteriaList.find { it.date == selectedDate.toString() }?.menus
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="cafeteria_no_menu">&#128517; 등록된 메뉴가 없어요.</string>
     <string name="cafeteria_korean">🍚 한식</string>
     <string name="cafeteria_another">🍛 일품</string>
-    <string name="cafeteria_another_list">김치볶음밥 4,900원 / 라면 4,000원 / 치즈라면 4,500원 / 해물짬뽕라면 4,500원 / 돈가스 5,000원 / 치즈돈가스 5,500원 / 고구마치즈돈까스 6,000원</string>
+    <string name="cafeteria_another_list">라면 3,500원 / 치즈라면 4,000원 / 해물라면 4,500원 / 돈까스 5,500원 / 치즈돈까스 5,500원 / 고구마치즈돈까스 6,000원 / 스팸김치볶음밥 4,900원 / 치킨마요덮밥 4,500원 / 불닭마요덮밥 4,500원 / 오므라이스 5,500원</string>
 
     <!-- license -->
     <string name="license_title">오픈소스 라이센스</string>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #233 

## ✍️ 구현 내용
- 일품 식단 가격 인하 및 메뉴 변동 내용을 반영하였습니다.
- 식단이 없을 때 빈 리스트로 오나, 코드에서는 `Null` 값으로 처리되어 반영되지 않던 오류를 수정하였습니다.

## 📷 구현 영상
|빈 식단|일반 식단|
|---|---|
|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/83814bbc-054e-4279-a5f9-1cabbfa573d4)|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/fb8a8235-23b3-419a-8046-2cea21deb4c1)|

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
