### PR TITLE
Fix : 식단 API 오류 수정

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -67,11 +67,13 @@ class CafeteriaViewModel(
     fun updateMenuList(selectedDate: LocalDate) {
         val cafeteriaList = _cafeteriaList.value ?: emptyList()
         _selectedDate.value = selectedDate
+        val selectedMenu = cafeteriaList.find { it.date == selectedDate.toString() }?.menus
         _menus.postValue(
-            cafeteriaList.find { it.date == selectedDate.toString() }?.menus
-                .takeIf { it.isNullOrEmpty() }
-                ?.let { emptyMenu }
-                ?: cafeteriaList.find { it.date == selectedDate.toString() }?.menus
+            if (selectedMenu.isNullOrEmpty()) {
+                emptyMenu
+            } else {
+                selectedMenu
+            }
         )
     }
 }


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #236 

## ✍️ 구현 내용
- 빈 식단을 받았을 경우 api 통신을 받는 부분을 수정하였습니다.
- `takeIf`로 로직을 받아 오류가 생긴 것으로 `if-else`로 수정하였습니다.

## 📷 구현 영상
|주말일 경우|날짜를 선택한 경우|
|---|---|
|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/2ef001b1-92b6-4c02-ac6a-bf11db769628)|![image](https://github.com/TeamDMU/DMU-Android/assets/84004687/ef7715d0-4d9c-41b5-957a-a1e4b5f821cd)|


## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
