### PR TITLE
Feat : 요일 별 일품 메뉴 업데이트

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,6 @@ android {
         versionCode 11
         versionName "2.0.1"
 
-        buildConfigField "String", "API_KEY", properties['API_KEY']
         buildConfigField "String", "BASE_URL", properties['BASE_URL']
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
@@ -5,17 +5,42 @@ import com.dongyang.android.youdongknowme.data.remote.service.CafeteriaService
 import com.dongyang.android.youdongknowme.standard.network.ErrorResponseHandler
 import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
+import com.dongyang.android.youdongknowme.standard.util.Weekdays
 
 class CafeteriaRepository(
-    private val errorResponseHandler: ErrorResponseHandler
+    private val errorResponseHandler: ErrorResponseHandler,
 ) {
     suspend fun fetchMenuList(): NetworkResult<List<Cafeteria>> {
         return try {
-            val response = RetrofitObject.getNetwork().create(CafeteriaService::class.java).getMenuList()
+            val response =
+                RetrofitObject.getNetwork().create(CafeteriaService::class.java).getMenuList()
             NetworkResult.Success(response)
         } catch (exception: Exception) {
             val error = errorResponseHandler.getError(exception)
             NetworkResult.Error(error)
         }
+    }
+
+    fun fetchAnotherMenus(todayDay: Weekdays): List<DaysMenu> {
+        return DaysMenu.values().filter { menu ->
+            menu.operatingDays.contains(todayDay)
+        }
+    }
+
+    enum class DaysMenu(
+        val menuNameKr: String,
+        val price: Int,
+        val operatingDays: List<Weekdays>,
+    ) {
+        PORKCUTLET("돈까스", 5_000, Weekdays.values().toList()),
+        CHEESE_PORKCUTLET("치즈돈까스", 5_500, Weekdays.values().toList()),
+        SWEET_POTATO_CHEESE_PORKCUTLET("고구마치즈돈까스", 6_000, Weekdays.values().toList()),
+        RAMEN("라면", 3_500, Weekdays.values().toList()),
+        CHEESE_RAMEN("치즈라면", 4_000, Weekdays.values().toList()),
+        SEAFOOD_RAMEN("해물라면", 4_500, Weekdays.values().toList()),
+        SPAM_KIMCHI_FRIED_RICE("스팸김치볶음밥", 4_900, listOf(Weekdays.MONDAY, Weekdays.TUESDAY)),
+        HOT_CHICKEN_MAYO_RICE("불닭마요덮밥", 4_500, listOf(Weekdays.WEDNESDAY, Weekdays.THURSDAY)),
+        CHICKEN_MAYO_RICE("치킨마요덮밥", 4_500, listOf(Weekdays.WEDNESDAY, Weekdays.THURSDAY)),
+        OMELET_RICE("오므라이스", 5_500, listOf(Weekdays.FRIDAY));
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
@@ -21,7 +21,7 @@ class CafeteriaRepository(
         }
     }
 
-    fun fetchAnotherMenus(todayDay: Weekdays): List<DaysMenu> {
+    fun fetchDaysMenu(todayDay: Weekdays): List<DaysMenu> {
         return DaysMenu.values().filter { menu ->
             menu.operatingDays.contains(todayDay)
         }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/data/repository/CafeteriaRepository.kt
@@ -8,7 +8,7 @@ import com.dongyang.android.youdongknowme.standard.network.RetrofitObject
 import com.dongyang.android.youdongknowme.standard.util.Weekdays
 
 class CafeteriaRepository(
-    private val errorResponseHandler: ErrorResponseHandler,
+    private val errorResponseHandler: ErrorResponseHandler
 ) {
     suspend fun fetchMenuList(): NetworkResult<List<Cafeteria>> {
         return try {
@@ -21,7 +21,7 @@ class CafeteriaRepository(
         }
     }
 
-    fun fetchDaysMenu(todayDay: Weekdays): List<DaysMenu> {
+    fun fetchDaysMenus(todayDay: Weekdays): List<DaysMenu> {
         return DaysMenu.values().filter { menu ->
             menu.operatingDays.contains(todayDay)
         }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/network/RetrofitObject.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/network/RetrofitObject.kt
@@ -16,7 +16,7 @@ object RetrofitObject {
             val request = chain.request().newBuilder()
             val originalHttpUrl = chain.request().url
 
-            val url = originalHttpUrl.newBuilder().addQueryParameter("api_key", BuildConfig.API_KEY)
+            val url = originalHttpUrl.newBuilder()
                 .build()
             request.url(url)
             chain.proceed(request.build())

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Weekdays.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Weekdays.kt
@@ -18,7 +18,7 @@ enum class Weekdays {
                 DayOfWeek.WEDNESDAY -> WEDNESDAY
                 DayOfWeek.THURSDAY -> THURSDAY
                 DayOfWeek.FRIDAY -> FRIDAY
-                else -> throw IllegalArgumentException("에러")
+                else -> throw IllegalArgumentException("월요일 - 금요일을 벗어났습니다.")
             }
         }
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Weekdays.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Weekdays.kt
@@ -1,0 +1,25 @@
+package com.dongyang.android.youdongknowme.standard.util
+
+import java.time.DayOfWeek
+
+enum class Weekdays(val dayKr: String) {
+    MONDAY("월"),
+    TUESDAY("화"),
+    WEDNESDAY("수"),
+    THURSDAY("목"),
+    FRIDAY("금");
+
+    companion object {
+
+        fun from(dayOfWeek: DayOfWeek): Weekdays {
+            return when (dayOfWeek) {
+                DayOfWeek.MONDAY -> MONDAY
+                DayOfWeek.TUESDAY -> TUESDAY
+                DayOfWeek.WEDNESDAY -> WEDNESDAY
+                DayOfWeek.THURSDAY -> THURSDAY
+                DayOfWeek.FRIDAY -> FRIDAY
+                else -> throw IllegalArgumentException("에러")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Weekdays.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/standard/util/Weekdays.kt
@@ -2,12 +2,12 @@ package com.dongyang.android.youdongknowme.standard.util
 
 import java.time.DayOfWeek
 
-enum class Weekdays(val dayKr: String) {
-    MONDAY("월"),
-    TUESDAY("화"),
-    WEDNESDAY("수"),
-    THURSDAY("목"),
-    FRIDAY("금");
+enum class Weekdays {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY;
 
     companion object {
 

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -73,7 +73,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             override fun bind(container: CafeteriaContainer, day: CalendarDay) = container.bind(day)
         }
 
-        viewModel.updateAnotherMenus(findNearestMonday(LocalDate.now()))
+        viewModel.updateDaysMenu(findNearestMonday(LocalDate.now()))
     }
 
     override fun initDataBinding() {
@@ -109,7 +109,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
 
         binding.cafeteriaErrorContainer.refresh.setOnClickListener {
             viewModel.fetchCafeteria()
-            viewModel.updateAnotherMenus(findNearestMonday(LocalDate.now()))
+            viewModel.updateDaysMenu(findNearestMonday(LocalDate.now()))
         }
 
         binding.cvCafeteriaCalendar.setOnTouchListener { _, event ->

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -86,11 +86,11 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             showToast(getString(resId))
         })
 
-        viewModel.koreaMenu.observe(viewLifecycleOwner) {
+        viewModel.koreaMenus.observe(viewLifecycleOwner) {
             koreanMenuAdapter.submitList(it)
         }
 
-        viewModel.daysMenu.observe(viewLifecycleOwner) {
+        viewModel.daysMenus.observe(viewLifecycleOwner) {
             anotherMenuAdapter.submitList(it)
         }
     }
@@ -145,7 +145,7 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             viewModel = viewModel,
             calendarView = binding.cvCafeteriaCalendar,
             oldDate = viewModel.selectedDate.value,
-            selectedDate = findNearestMonday(LocalDate.now()),
+            selectedDate = findNearestMonday(LocalDate.now())
         )
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaFragment.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.util.TypedValue
 import android.view.MotionEvent
 import android.view.View
-import androidx.recyclerview.widget.RecyclerView
 import androidx.window.layout.WindowMetricsCalculator
 import com.dongyang.android.youdongknowme.R
 import com.dongyang.android.youdongknowme.databinding.FragmentCafeteriaBinding
@@ -17,11 +16,10 @@ import com.kizitonwose.calendarview.model.CalendarDay
 import com.kizitonwose.calendarview.ui.DayBinder
 import com.kizitonwose.calendarview.utils.Size
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import java.time.DayOfWeek
+import java.time.DayOfWeek.*
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.temporal.TemporalAdjusters
-
 
 class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewModel>(),
     CalendarInterface {
@@ -60,9 +58,9 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
         binding.cvCafeteriaCalendar.apply {
             val dayWidth = wmc.bounds.width() / 5
             val dayHeight: Int = TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP,
-            124f,
-            resources.displayMetrics
+                TypedValue.COMPLEX_UNIT_DIP,
+                124f,
+                resources.displayMetrics
             ).toInt()
 
             daySize = Size(dayWidth, dayHeight)
@@ -74,10 +72,11 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
 
             override fun bind(container: CafeteriaContainer, day: CalendarDay) = container.bind(day)
         }
+
+        viewModel.updateAnotherMenus(findNearestMonday(LocalDate.now()))
     }
 
     override fun initDataBinding() {
-
         viewModel.isLoading.observe(viewLifecycleOwner) {
             if (it) showLoading()
             else dismissLoading()
@@ -87,10 +86,12 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
             showToast(getString(resId))
         })
 
-        viewModel.menus.observe(viewLifecycleOwner) {
+        viewModel.koreaMenu.observe(viewLifecycleOwner) {
             koreanMenuAdapter.submitList(it)
-            // 일품 메뉴 : 일품 메뉴는 리스트로 제작하여 등록
-            anotherMenuAdapter.submitList(getString(R.string.cafeteria_another_list).split("/").map { it.trim() })
+        }
+
+        viewModel.daysMenu.observe(viewLifecycleOwner) {
+            anotherMenuAdapter.submitList(it)
         }
     }
 
@@ -101,13 +102,14 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
         binding.cvCafeteriaCalendar.setup(
             YearMonth.from(nearestMonday),
             YearMonth.from(nearestMonday.plusDays(4)),
-            DayOfWeek.MONDAY
+            MONDAY
         )
 
         binding.cvCafeteriaCalendar.scrollToDate(nearestMonday)
 
         binding.cafeteriaErrorContainer.refresh.setOnClickListener {
             viewModel.fetchCafeteria()
+            viewModel.updateAnotherMenus(findNearestMonday(LocalDate.now()))
         }
 
         binding.cvCafeteriaCalendar.setOnTouchListener { _, event ->
@@ -123,16 +125,16 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
 
     private fun findNearestMonday(currentDate: LocalDate): LocalDate {
         return when (currentDate.dayOfWeek) {
-            DayOfWeek.SATURDAY, DayOfWeek.SUNDAY -> {
-                currentDate.with(TemporalAdjusters.next(DayOfWeek.MONDAY))
+            SATURDAY, SUNDAY -> {
+                currentDate.with(TemporalAdjusters.next(MONDAY))
             }
 
-            DayOfWeek.MONDAY -> {
+            MONDAY -> {
                 currentDate
             }
 
             else -> {
-                currentDate.with(TemporalAdjusters.previous(DayOfWeek.MONDAY))
+                currentDate.with(TemporalAdjusters.previous(MONDAY))
             }
         }
     }
@@ -140,10 +142,10 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding, CafeteriaViewMo
     override fun onPause() {
         super.onPause()
         notifyDateChanged(
-            viewModel,
-            binding.cvCafeteriaCalendar,
-            viewModel.selectedDate.value,
-            LocalDate.now()
+            viewModel = viewModel,
+            calendarView = binding.cvCafeteriaCalendar,
+            oldDate = viewModel.selectedDate.value,
+            selectedDate = findNearestMonday(LocalDate.now()),
         )
     }
 }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -82,7 +82,7 @@ class CafeteriaViewModel(
         )
     }
 
-    fun updateAnotherMenus(selectedDate: LocalDate) {
+    fun updateDaysMenu(selectedDate: LocalDate) {
         viewModelScope.launch {
             val dateToWeekday: Weekdays = Weekdays.from(selectedDate.dayOfWeek)
             runCatching {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -35,11 +35,11 @@ class CafeteriaViewModel(
     private val _cafeteriaList: MutableLiveData<List<Cafeteria>> = MutableLiveData()
     val cafeteriaList: LiveData<List<Cafeteria>> = _cafeteriaList
 
-    private val _koreaMenu: MutableLiveData<List<String>> = MutableLiveData()
-    val koreaMenu: LiveData<List<String>> = _koreaMenu
+    private val _koreaMenus: MutableLiveData<List<String>> = MutableLiveData()
+    val koreaMenus: LiveData<List<String>> = _koreaMenus
 
-    private val _daysMenu: MutableLiveData<List<String>> = MutableLiveData()
-    val daysMenu: LiveData<List<String>> = _daysMenu
+    private val _daysMenus: MutableLiveData<List<String>> = MutableLiveData()
+    val daysMenus: LiveData<List<String>> = _daysMenus
 
     private val emptyMenu = listOf(resourceProvider.getString(R.string.cafeteria_no_menu))
 
@@ -73,7 +73,7 @@ class CafeteriaViewModel(
         val cafeteriaList = _cafeteriaList.value ?: emptyList()
         _selectedDate.value = selectedDate
         val selectedMenu = cafeteriaList.find { it.date == selectedDate.toString() }?.menus
-        _koreaMenu.postValue(
+        _koreaMenus.postValue(
             if (selectedMenu.isNullOrEmpty()) {
                 emptyMenu
             } else {
@@ -86,11 +86,11 @@ class CafeteriaViewModel(
         viewModelScope.launch {
             val dateToWeekday: Weekdays = Weekdays.from(selectedDate.dayOfWeek)
             runCatching {
-                cafeteriaRepository.fetchDaysMenu(dateToWeekday)
-            }.onSuccess { daysMenu ->
+                cafeteriaRepository.fetchDaysMenus(dateToWeekday)
+            }.onSuccess { daysMenus ->
                 val formatter = DecimalFormat("#,###")
-                val formattedMenuWithPrice = daysMenu.map { "${it.menuNameKr} ${formatter.format(it.price)}원" }
-                _daysMenu.value = formattedMenuWithPrice
+                val formattedMenuWithPrice = daysMenus.map { "${it.menuNameKr} ${formatter.format(it.price)}원" }
+                _daysMenus.value = formattedMenuWithPrice
             }.onFailure {
                 _isError.value = true
             }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CafeteriaViewModel.kt
@@ -86,7 +86,7 @@ class CafeteriaViewModel(
         viewModelScope.launch {
             val dateToWeekday: Weekdays = Weekdays.from(selectedDate.dayOfWeek)
             runCatching {
-                cafeteriaRepository.fetchAnotherMenus(dateToWeekday)
+                cafeteriaRepository.fetchDaysMenu(dateToWeekday)
             }.onSuccess { daysMenu ->
                 val formatter = DecimalFormat("#,###")
                 val formattedMenuWithPrice = daysMenu.map { "${it.menuNameKr} ${formatter.format(it.price)}원" }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CalendarInterface.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CalendarInterface.kt
@@ -11,6 +11,7 @@ interface CalendarInterface {
         selectedDate: LocalDate
     ) {
         viewModel.updateMenuList(selectedDate)
+        viewModel.updateAnotherMenus(selectedDate)
         calendarView.notifyDateChanged(selectedDate)
         oldDate?.let { calendarView.notifyDateChanged(it) }
     }

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CalendarInterface.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/cafeteria/CalendarInterface.kt
@@ -11,7 +11,7 @@ interface CalendarInterface {
         selectedDate: LocalDate
     ) {
         viewModel.updateMenuList(selectedDate)
-        viewModel.updateAnotherMenus(selectedDate)
+        viewModel.updateDaysMenu(selectedDate)
         calendarView.notifyDateChanged(selectedDate)
         oldDate?.let { calendarView.notifyDateChanged(it) }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,12 +122,11 @@
     <string name="cafeteria_student">학생식당</string>
     <string name="cafeteria_menu">메뉴</string>
     <string name="cafeteria_lunch">점심</string>
-    <string name="cafeteria_time">11:30 - 14:00, 16:30 - 18:00</string>
+    <string name="cafeteria_time">11:00 - 14:00, 16:30 - 18:00</string>
     <string name="cafeteria_place">8호관 3층</string>
     <string name="cafeteria_no_menu">&#128517; 등록된 메뉴가 없어요.</string>
     <string name="cafeteria_korean">🍚 한식</string>
     <string name="cafeteria_another">🍛 일품</string>
-    <string name="cafeteria_another_list">라면 3,500원 / 치즈라면 4,000원 / 해물라면 4,500원 / 돈까스 5,500원 / 치즈돈까스 5,500원 / 고구마치즈돈까스 6,000원 / 스팸김치볶음밥 4,900원 / 치킨마요덮밥 4,500원 / 불닭마요덮밥 4,500원 / 오므라이스 5,500원</string>
 
     <!-- license -->
     <string name="license_title">오픈소스 라이센스</string>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #264 

## ✍️ 구현 내용
- 수정된 일품 메뉴를 업데이트 했습니다.
- 요일 별로 상이한 일품 메뉴를 출력했습니다.
- data layer 에서 일품 메뉴를 가지고 있고, view에서 찾은 요일을 data layer 로 메서드 호출하여 데이터 값을 가져옵니다.
- 기존 뷰모델에서의 `menu` > `koreaMenu` 로 수정했고, 일품 메뉴는 `daysMenu` 라는 변수명을 사용합니다.
- 사용하지 않는 `API_KEY` 제거 했습니다. 로컬 프로퍼티에서도 제거해도 됩니다!

## 📷 구현 영상

https://github.com/user-attachments/assets/96bdfd41-4827-43b2-8c4a-c7fcda344665

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
