### PR TITLE
Refactor : 학사 일정 범위 및 출력 방식 수정

### DIFF
--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleFragment.kt
@@ -1,14 +1,7 @@
 package com.dongyang.android.youdongknowme.ui.view.schedule
 
 import android.content.res.ColorStateList
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.PorterDuff
-import android.graphics.drawable.BitmapDrawable
-import android.graphics.drawable.Drawable
 import androidx.core.content.ContextCompat
-import androidx.core.content.res.ResourcesCompat
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dongyang.android.youdongknowme.R
@@ -75,10 +68,16 @@ class ScheduleFragment : BaseFragment<FragmentScheduleBinding, ScheduleViewModel
         }
 
         // 최소 날짜, 최대 날짜 지정
+        if(viewModel.currentYear.value == null || viewModel.currentYear.value != LocalDate.now().year){
+            viewModel.setCurrentYear(LocalDate.now())
+        }
+
         binding.mvScheduleCalendar.apply {
-            this.state().edit().setMinimumDate(CalendarDay.from(2023, 1, 1))
-                .setMaximumDate(CalendarDay.from(2025, 2, 28))
-                .commit()
+            viewModel.currentYear.value?.let{
+                this.state().edit().setMinimumDate(CalendarDay.from(it-1, 1, 1))
+                    .setMaximumDate(CalendarDay.from(it+1, 2, 28))
+                    .commit()
+            }
         }
 
         // 연/월 방식으로 타이틀 처리

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
@@ -11,6 +11,8 @@ import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.ui.view.util.Event
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import kotlinx.coroutines.launch
+import org.threeten.bp.LocalDate
+import java.util.Date
 
 /* 학사 일정 뷰모델 */
 class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : BaseViewModel() {
@@ -33,9 +35,16 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : Ba
     private val _pickMonth = MutableLiveData<Int>()
     val pickMonth: LiveData<Int> = _pickMonth
 
+    private var _currentYear = MutableLiveData<Int>()
+    val currentYear: LiveData<Int> = _currentYear
+
     fun setPickedDate(date: CalendarDay) {
         _pickYear.value = date.year
         _pickMonth.value = date.month
+    }
+
+    fun setCurrentYear(date: LocalDate){
+        _currentYear.value = date.year
     }
 
     fun getSchedules() {

--- a/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/dongyang/android/youdongknowme/ui/view/schedule/ScheduleViewModel.kt
@@ -3,15 +3,12 @@ package com.dongyang.android.youdongknowme.ui.view.schedule
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.dongyang.android.youdongknowme.data.local.SharedPreference.NO_SCHEDULE
 import com.dongyang.android.youdongknowme.data.remote.entity.Schedule
 import com.dongyang.android.youdongknowme.data.remote.entity.ScheduleEntry
 import com.dongyang.android.youdongknowme.data.repository.ScheduleRepository
 import com.dongyang.android.youdongknowme.standard.base.BaseViewModel
 import com.dongyang.android.youdongknowme.standard.network.NetworkResult
 import com.dongyang.android.youdongknowme.ui.view.util.Event
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import kotlinx.coroutines.launch
 
@@ -42,41 +39,25 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository) : Ba
     }
 
     fun getSchedules() {
-        // 로컬에 저장한 데이터가 없으면 네트워크에서 데이터를 받아와 로컬에 저장 및 화면에 출력
-        if (scheduleRepository.getLocalSchedules() == NO_SCHEDULE) {
-            _isLoading.postValue(true)
-            viewModelScope.launch {
-                when (val result = scheduleRepository.fetchSchedules()) {
-                    is NetworkResult.Success -> {
-                        val scheduleList = result.data
+        _isLoading.postValue(true)
+        viewModelScope.launch {
+            when (val result = scheduleRepository.fetchSchedules()) {
+                is NetworkResult.Success -> {
+                    val scheduleList = result.data
 
-                        // 선택한 연월 조건에 따라 리스트 출력
+                    // 선택한 연월 조건에 따라 리스트 출력
+                    _scheduleList.postValue(getSchedulesForPickDate(scheduleList))
 
-                        _scheduleList.postValue(getSchedulesForPickDate(scheduleList))
+                    _isError.postValue(false)
+                    _isLoading.postValue(false)
+                }
 
-                        scheduleRepository.setLocalSchedules(Gson().toJson(scheduleList))
-                        _isError.postValue(false)
-                        _isLoading.postValue(false)
-                    }
-
-                    is NetworkResult.Error -> {
-                        handleError(result, _errorState)
-                        _isError.postValue(true)
-                        _isLoading.postValue(false)
-                    }
+                is NetworkResult.Error -> {
+                    handleError(result, _errorState)
+                    _isError.postValue(true)
+                    _isLoading.postValue(false)
                 }
             }
-        } else {
-            // 저장한 데이터가 있으면 로컬에서 곧바로 데이터를 받아와 화면에 출력
-            val localSchedules = scheduleRepository.getLocalSchedules()
-            val scheduleList = getSchedulesForPickDate(
-                Gson().fromJson(
-                    localSchedules,
-                    object : TypeToken<List<Schedule>>() {}.type
-                )
-            )
-            _isError.postValue(false)
-            _scheduleList.postValue(scheduleList)
         }
     }
 


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #270 

## ✍️ 구현 내용
- 기존 하드 코딩된 학사 일정의 범위를 조정하였습니다.
- currentYear을 지정하고 LocalDate와 비교하여 다를 경우 출력 범위를 조정합니다.
- 학사 일정에 변동이 있는 경우가 있어 로컬 저장 방식을 제거하였습니다.
   이는 추후 로컬 저장 데이터와 현재 데이터와 비교하여 다를 경우만 로컬 데이터를 변경하여 로드 하는 방식이 효율적일듯 합니다.
- currentYear은 월 단위만 유효하기 떄문에 2월의 윤달은 체크하지 않았습니다.
- firstLaunchCheck로 currentYear을 초기 설정하는 방식도 있으나 LocalDate와의 비교 부분이 있어 nullCheck를 비교와 같이 넣어도 충분할거 같습니다.

## 📷 구현 영상

https://github.com/user-attachments/assets/03b3cdb4-df01-4e18-996e-e91622b04103


## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과
